### PR TITLE
express-openapi: Only add basePath, host to apiDoc if swagger document. (fixes #142)

### DIFF
--- a/packages/express-openapi/index.js
+++ b/packages/express-openapi/index.js
@@ -354,8 +354,10 @@ function initialize(args) {
     // Swagger UI support
     app.get(basePath + docsPath, function(req, res, next) {
       req.apiDoc = copy(apiDoc);
-      req.apiDoc.host = req.headers.host;
-      req.apiDoc.basePath = req.baseUrl + basePath;
+      if (apiDoc.swagger) {
+        req.apiDoc.host = req.headers.host;
+        req.apiDoc.basePath = req.baseUrl + basePath;
+      }
       securityFilter(req, res, next);
     });
   }


### PR DESCRIPTION
…t. (fixes #142)