### PR TITLE
[express-openapi] Add alternative routes/paths specifications to definitions

### DIFF
--- a/packages/express-openapi/index.d.ts
+++ b/packages/express-openapi/index.d.ts
@@ -11,8 +11,10 @@ export interface Args {
     apiDoc: OpenAPI.Document | string
     app: express.Application
     routes?: string | string[]
-    paths: string | string[]
+    paths: string | string[] | { path: string, module: any }[]
     pathsIgnore?: RegExp
+    routesGlob?: string;
+    routesIndexFileRegExp: RegExp;
     docsPath?: string
     errorMiddleware?: express.ErrorRequestHandler,
     errorTransformer?(openapiError: OpenapiError, jsonschemaError: JsonschemaError): any


### PR DESCRIPTION
TypeScript definitions were missing `paths` objects, `routesGlob`, and `indexFileRegExp`.