### PR TITLE
Fix: Request validator does not validate query params in OpenAPI 3

### DIFF
--- a/packages/openapi-jsonschema-parameters/index.js
+++ b/packages/openapi-jsonschema-parameters/index.js
@@ -6,7 +6,7 @@ function convert(parameters) {
   var formDataSchema = getSchema(parameters, 'formData');
   var headerSchema = getSchema(parameters, 'header');
   var pathSchema = getSchema(parameters, 'path');
-  var querySchema = getSchema(parameters, 'query');
+  var querySchema = getQuerySchema(parameters);
 
   if (bodySchema) {
     parametersSchema.body = bodySchema;
@@ -87,6 +87,25 @@ function getBodySchema(parameters) {
   }
 
   return bodySchema;
+}
+
+function getQuerySchema(parameters) {
+  var params = parameters.filter(byIn('query'));
+  var schema;
+
+  if (params.length) {
+    schema = {properties: {}};
+
+    params.forEach(function(param) {
+      var paramSchema = copyValidationKeywords(param.schema || param);
+
+      schema.properties[param.name] = handleNullable(param.schema || param, paramSchema);
+    });
+
+    schema.required = getRequiredParams(params);
+  }
+
+  return schema;
 }
 
 function getSchema(parameters, type) {

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-nullable-query-param-to-json-schema-openapi3.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-nullable-query-param-to-json-schema-openapi3.js
@@ -1,0 +1,30 @@
+module.exports = {
+  parameters: [
+    {
+      in: 'query',
+      name: 'foo',
+      required: true,
+      schema: {
+        nullable: true,
+        type: 'string'
+      }
+    }
+  ],
+  outputSchema: {
+    query: {
+      properties: {
+        foo: {
+          'anyOf': [
+            {
+              'type': 'string'
+            },
+            {
+              'type': 'null'
+            }
+          ]
+        }
+      },
+      required: ['foo']
+    }
+  }
+};

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-multiple-basic-query-params-to-json-schema-openapi3.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-multiple-basic-query-params-to-json-schema-openapi3.js
@@ -1,0 +1,34 @@
+module.exports = {
+  parameters: [
+    {
+      in: 'query',
+      name: 'foo',
+      required: true,
+      schema: {
+        type: 'string'
+      }
+    },
+    {
+      in: 'query',
+      name: 'boo',
+      required: true,
+      schema: {
+        type: 'string'
+      }
+    }
+  ],
+
+  outputSchema: {
+    query: {
+      properties: {
+        foo: {
+          type: 'string'
+        },
+        boo: {
+          type: 'string'
+        }
+      },
+      required: ['foo', 'boo']
+    }
+  }
+};

--- a/packages/openapi-jsonschema-parameters/test/data-driven/handle-some-required-query-params-openapi3.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/handle-some-required-query-params-openapi3.js
@@ -1,0 +1,34 @@
+module.exports = {
+  parameters: [
+    {
+      in: 'query',
+      name: 'foo',
+      required: false,
+      schema: {
+        type: 'string'
+      }
+    },
+    {
+      in: 'query',
+      name: 'boo',
+      required: true,
+      schema: {
+        type: 'string'
+      }
+    }
+  ],
+
+  outputSchema: {
+    query: {
+      properties: {
+        foo: {
+          type: 'string'
+        },
+        boo: {
+          type: 'string'
+        }
+      },
+      required: ['boo']
+    }
+  }
+};


### PR DESCRIPTION
OpenAPI 3 moved query parameter schemas under their own schema object, see the [parameter object](https://swagger.io/specification/#parameterObject) specification.