### PR TITLE
Add test for OpenAPI 3 query parameters

### DIFF
--- a/packages/openapi-request-validator/test/data-driven/accept-custom-formats-openapi3.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-custom-formats-openapi3.js
@@ -1,0 +1,26 @@
+module.exports = {
+  validateArgs: {
+    parameters: [
+      {
+        in: "query",
+        name: "foo",
+        schema: {
+          type: "string",
+          format: "foo"
+        }
+      }
+    ],
+    schemas: null,
+    customFormats: {
+      foo: function(input) {
+        return input === 'foo'
+      }
+    }
+  },
+  request: {
+    path: "?foo=foo",
+    query: {
+      foo: "foo"
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/fail-customFormats-for-openapi3-query-param.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-customFormats-for-openapi3-query-param.js
@@ -1,0 +1,38 @@
+module.exports = {
+  "validateArgs": {
+    "parameters": [
+      {
+        "in": "query",
+        "name": "foo",
+        "schema": {
+          "type": "string",
+          "format": "foo",
+        },
+        "required": true,
+      }
+    ],
+    "schemas": null,
+    "customFormats": {
+      foo: function(input) {
+        return input === 'foo'
+      }
+    }
+  },
+  "request": {
+    "path": "?foo=boo",
+    "query": {
+      "foo": "boo"
+    }
+  },
+  "expectedError": {
+    "status": 400,
+    "errors": [
+      {
+        "path": "foo",
+        "errorCode": "format.openapi.validation",
+        "message": "instance.foo does not conform to the \"foo\" format",
+        "location": "query"
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Just a test for openapi-request-validator corresponding to the fix in openapi-jsonschema-parameters. Probably not ready to be merged until the greenkeeper package update lands.