### PR TITLE
export SchemaObject "type" property type

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -107,16 +107,17 @@ export namespace OpenAPIV3 {
     examples?: { [media: string]: ReferenceObject | ExampleObject }
     content?: { [media: string]: MediaTypeObject }
   }
-
+  export type NonArraySchemaObjectType = 'null' | 'boolean' | 'object' | 'number' | 'string' | 'integer'
+  export type ArraySchemaObjectType = 'array'
   export type SchemaObject = ArraySchemaObject | NonArraySchemaObject
 
   interface ArraySchemaObject extends BaseSchemaObject {
-    type: 'array'
+    type: ArraySchemaObjectType
     items: ReferenceObject | SchemaObject
   }
 
   interface NonArraySchemaObject extends BaseSchemaObject {
-    type: 'null' | 'boolean' | 'object' | 'number' | 'string' | 'integer'
+    type: NonArraySchemaObjectType
   }
 
   interface BaseSchemaObject {


### PR DESCRIPTION
My typescript project wouldn't compile without casting my schema types as "string" | "number" | "boolean" | "object" | "integer" | "null". I created a type to match the one correct string literal locally but this way we can export the correct types in case the spec changes.