### PR TITLE
openapi-request-validator: use ajv instead of jsonschema for validation

### DIFF
--- a/packages/openapi-request-validator/README.md
+++ b/packages/openapi-request-validator/README.md
@@ -76,15 +76,15 @@ A function that transforms errors.
 This function is passed 2 arguments.
 
 ```
-  errorTransformer: function(openapiError, jsonschemaError) {
+  errorTransformer: function(openapiError, ajvError) {
     return {
       message: openapiError.message
     };
   }
 ```
 
-See the error format in [jsonschema](https://www.npmjs.com/package/jsonschema) for
-`jsonschemaError`.  `openapiError`s have the following properties:
+See the error format in [ajv](https://www.npmjs.com/package/ajv#validation-errors) for
+`ajvError`.  `openapiError`s have the following properties:
 
 * `errorCode` - A jsonschema error suffixed with `.openapi.validation`.
 * `location` - One of `body`, `headers`, `path`, or `query`.  Signifies where validation

--- a/packages/openapi-request-validator/package-lock.json
+++ b/packages/openapi-request-validator/package-lock.json
@@ -4,15 +4,49 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+    "ajv": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "requires": {
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "openapi-jsonschema-parameters": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-0.5.0.tgz",
       "integrity": "sha512-lm+Q1MZvgx+YOt36eVKhAHQNYVsmwYRu61yBD8aOoM/y5lad4GZp2KcDsPY7Z7MH1Qjzov7jPLqmJt3Hqt8tUw=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "2.1.1"
+      }
     }
   }
 }

--- a/packages/openapi-request-validator/package.json
+++ b/packages/openapi-request-validator/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/kogosoftwarellc/open-api/tree/master/packages/openapi-request-validator#readme",
   "dependencies": {
-    "jsonschema": "1.2.4",
+    "ajv": "^6.5.2",
     "openapi-jsonschema-parameters": "0.5.0"
   }
 }

--- a/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-body-property.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-body-property.js
@@ -33,7 +33,7 @@ module.exports = {
       {
         "path": "foo",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"foo\"",
+        "message": "should have required property 'foo'",
         "location": "body"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-formData-property.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-formData-property.js
@@ -18,7 +18,7 @@ module.exports = {
       {
         "path": "foo",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"foo\"",
+        "message": "should have required property 'foo'", 
         "location": "formData"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-header-param.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-header-param.js
@@ -17,7 +17,7 @@ module.exports = {
       {
         "path": "foo",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"foo\"",
+        "message": "should have required property 'foo'",
         "location": "headers"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-query-param.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-query-param.js
@@ -17,7 +17,7 @@ module.exports = {
       {
         "path": "foo",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"foo\"",
+        "message": "should have required property 'foo'",
         "location": "query"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-an-invalid-path-param.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-an-invalid-path-param.js
@@ -23,7 +23,7 @@ module.exports = {
       {
         "path": "path1",
         "errorCode": "pattern.openapi.validation",
-        "message": "instance.path1 does not match pattern \"^a$\"",
+        "message": "should match pattern \"^a$\"",
         "location": "path"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-an-unknown-ref-in-body.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-an-unknown-ref-in-body.js
@@ -18,7 +18,7 @@ module.exports = {
     "status": 400,
     "errors": [
       {
-        "message": "no such schema #/definitions/TestBody located in </>",
+        "message": "can't resolve reference #/definitions/TestBody",
         "schema": {
           "$ref": "#/definitions/TestBody"
         },

--- a/packages/openapi-request-validator/test/data-driven/fail-body-expecting-array.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-body-expecting-array.js
@@ -19,7 +19,7 @@ module.exports = {
     "errors": [
       {
         "errorCode": "type.openapi.validation",
-        "message": "instance is not of a type(s) array",
+        "message": "should be array",
         "location": "body"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-customFormats-for-openapi3-query-param.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-customFormats-for-openapi3-query-param.js
@@ -30,7 +30,7 @@ module.exports = {
       {
         "path": "foo",
         "errorCode": "format.openapi.validation",
-        "message": "instance.foo does not conform to the \"foo\" format",
+        "message": "should match format \"foo\"",
         "location": "query"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-customFormats.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-customFormats.js
@@ -28,7 +28,7 @@ module.exports = {
       {
         "path": "foo",
         "errorCode": "format.openapi.validation",
-        "message": "instance.foo does not conform to the \"foo\" format",
+        "message": "should match format \"foo\"",
         "location": "query"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-external-ref-in-body.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-external-ref-in-body.js
@@ -58,13 +58,13 @@ module.exports = {
       {
         "path": "test1",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test1\"",
+        "message": "should have required property 'test1'",
         "location": "body"
       },
       {
         "path": "test2",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test2\"",
+        "message": "should have required property 'test2'",
         "location": "body"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-external-ref-through-local-ref-in-body.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-external-ref-through-local-ref-in-body.js
@@ -65,13 +65,13 @@ module.exports = {
       {
         "path": "test1",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test1\"",
+        "message": "should have required property 'test1'",
         "location": "body"
       },
       {
         "path": "test2",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test2\"",
+        "message": "should have required property 'test2'",
         "location": "body"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-missing-path-params.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-missing-path-params.js
@@ -19,7 +19,7 @@ module.exports = {
       {
         "path": "path1",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"path1\"",
+        "message": "should have required property 'path1'",
         "location": "path"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-multiple-invalid-path-params.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-multiple-invalid-path-params.js
@@ -31,13 +31,13 @@ module.exports = {
       {
         "path": "path1",
         "errorCode": "pattern.openapi.validation",
-        "message": "instance.path1 does not match pattern \"^a$\"",
+        "message": "should match pattern \"^a$\"",
         "location": "path"
       },
       {
         "path": "path2",
         "errorCode": "pattern.openapi.validation",
-        "message": "instance.path2 does not match pattern \"^f$\"",
+        "message": "should match pattern \"^f$\"",
         "location": "path"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-multiple-local-refs-in-body.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-multiple-local-refs-in-body.js
@@ -55,13 +55,13 @@ module.exports = {
       {
         "path": "test1",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test1\"",
+        "message": "should have required property 'test1'",
         "location": "body"
       },
       {
         "path": "test2",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test2\"",
+        "message": "should have required property 'test2'",
         "location": "body"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-multiple-missing-local-refs-in-body.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-multiple-missing-local-refs-in-body.js
@@ -55,13 +55,13 @@ module.exports = {
       {
         "path": "test1",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test1\"",
+        "message": "should have required property 'test1'",
         "location": "body"
       },
       {
         "path": "test2",
         "errorCode": "required.openapi.validation",
-        "message": "instance requires property \"test2\"",
+        "message": "should have required property 'test2'",
         "location": "body"
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-recursive-ref-in-body-as-object.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-recursive-ref-in-body-as-object.js
@@ -50,7 +50,7 @@ module.exports = {
       {
         path: 'test1.recursive.foo',
         errorCode: 'type.openapi.validation',
-        message: 'instance.test1.recursive.foo is not of a type(s) string',
+        message: 'should be string',
         location: 'body'
       }
     ]

--- a/packages/openapi-request-validator/test/data-driven/fail-schema-ref-in-body.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-schema-ref-in-body.js
@@ -34,7 +34,7 @@ module.exports = {
       {
         'path': 'foo',
         'errorCode': 'required.openapi.validation',
-        'message': 'instance requires property "foo"',
+        'message': 'should have required property \'foo\'',
         'location': 'body'
       }
     ]


### PR DESCRIPTION
We have started to use this library for some of our production services, and during profiling we noticed that a large amount of the processing time for requests was being spent validating incoming requests.

To improve this situation, I have ported `openapi-request-validator` to use [`ajv`](https://ajv.js.org/) rather than `jsonschema`. In many cases this change results in speed-ups of 1-3 orders of magnitude, especially with more complex schemas involved.

I have run all positive test cases as benchmarks using the old and the new code, and published a gist with the raw results here: https://gist.github.com/srijs/b6d6e01931d6fe20d65c90f6d275f35c

The main reason `ajv` achieves these speed-ups is that it compiles the schema eagerly into a validation function, rather than interpreting the schema repeatedly on each validation.

I'm opening this PR to gauge your interest in upstreaming this change. There are some potential follow-up changes (e.g. porting `openapi-response-validator` and `openapi-schema-validator`), which I'm happy to include as part of this PR, or do as separate PRs.

Looking forward to discussing this!