### PR TITLE
openapi-response-validator: use ajv instead of jsonschema for validation

### DIFF
--- a/packages/openapi-response-validator/README.md
+++ b/packages/openapi-response-validator/README.md
@@ -122,15 +122,15 @@ This object is used to support `$ref` in your responses
 This function is passed 2 arguments.
 
 ```
-  errorTransformer: function(openapiError, jsonschemaError) {
+  errorTransformer: function(openapiError, ajvError) {
     return {
       message: openapiError.message
     };
   }
 ```
 
-See the error format in [jsonschema](https://www.npmjs.com/package/jsonschema) for
-`jsonschemaError`.  `openapiError`s have the following properties:
+See the error format in [ajv](https://www.npmjs.com/package/ajv#validation-errors) for
+`ajvError`.  `openapiError`s have the following properties:
 
 * `errorCode` - A jsonschema error suffixed with `.openapi.validation`.
 failed.

--- a/packages/openapi-response-validator/package-lock.json
+++ b/packages/openapi-response-validator/package-lock.json
@@ -4,10 +4,44 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+    "ajv": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "requires": {
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "2.1.1"
+      }
     }
   }
 }

--- a/packages/openapi-response-validator/package.json
+++ b/packages/openapi-response-validator/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/kogosoftwarellc/open-api/tree/master/packages/eopenapi-response-validator#readme",
   "dependencies": {
-    "jsonschema": "1.2.4"
+    "ajv": "^6.5.2"
   }
 }

--- a/packages/openapi-response-validator/test/data-driven/fail-any-response-with-undefined-schema.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-any-response-with-undefined-schema.js
@@ -28,7 +28,7 @@ module.exports = {
     errors: [
       {
         errorCode: 'type.openapi.responseValidation',
-        message: 'response is not of a type(s) null'
+        message: 'response should be null'
       }
     ]
   }

--- a/packages/openapi-response-validator/test/data-driven/fail-customFormats.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-customFormats.js
@@ -33,12 +33,7 @@ module.exports = {
       {
         path: 'foo',
         errorCode: 'type.openapi.responseValidation',
-        message: 'foo is not of a type(s) string'
-      },
-      {
-        errorCode: 'format.openapi.responseValidation',
-        message: 'foo does not conform to the "foo" format',
-        path: 'foo'
+        message: 'foo should be string'
       }
     ]
   }

--- a/packages/openapi-response-validator/test/data-driven/fail-invalid-response.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-invalid-response.js
@@ -26,7 +26,7 @@ module.exports = {
       {
         path: 'foo',
         errorCode: 'type.openapi.responseValidation',
-        message: 'foo is not of a type(s) string'
+        message: 'foo should be string'
       }
     ]
   }

--- a/packages/openapi-response-validator/test/data-driven/fail-response-against-undefined-schema.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-response-against-undefined-schema.js
@@ -14,7 +14,7 @@ module.exports = {
     errors: [
       {
         errorCode: 'type.openapi.responseValidation',
-        message: 'response is not of a type(s) null'
+        message: 'response should be null'
       }
     ]
   }

--- a/packages/openapi-response-validator/test/data-driven/fail-unexpected-empty-response.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-unexpected-empty-response.js
@@ -25,7 +25,7 @@ module.exports = {
     errors: [
       {
         errorCode: 'type.openapi.responseValidation',
-        message: 'response is not of a type(s) object'
+        message: 'response should be object'
       }
     ]
   }

--- a/packages/openapi-response-validator/test/data-driven/fail-with-definition-references.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-with-definition-references.js
@@ -30,7 +30,7 @@ module.exports = {
       {
         path: 'foo',
         errorCode: 'type.openapi.responseValidation',
-        message: 'foo is not of a type(s) string'
+        message: 'foo should be string'
       }
     ]
   }

--- a/packages/openapi-response-validator/test/data-driven/fail-with-external-references-through-local-ref.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-with-external-references-through-local-ref.js
@@ -36,7 +36,7 @@ module.exports = {
             {
                 path: 'foo',
                 errorCode: 'type.openapi.responseValidation',
-                message: 'foo is not of a type(s) string'
+                message: 'foo should be string'
             }
         ]
     }

--- a/packages/openapi-response-validator/test/data-driven/fail-with-external-references-with-path-through-local-ref.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-with-external-references-with-path-through-local-ref.js
@@ -40,7 +40,7 @@ module.exports = {
             {
                 path: 'foo',
                 errorCode: 'type.openapi.responseValidation',
-                message: 'foo is not of a type(s) string'
+                message: 'foo should be string'
             }
         ]
     }

--- a/packages/openapi-response-validator/test/data-driven/fail-with-external-references-with-path.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-with-external-references-with-path.js
@@ -36,7 +36,7 @@ module.exports = {
             {
                 path: 'foo',
                 errorCode: 'type.openapi.responseValidation',
-                message: 'foo is not of a type(s) string'
+                message: 'foo should be string'
             }
         ]
     }

--- a/packages/openapi-response-validator/test/data-driven/fail-with-external-references.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-with-external-references.js
@@ -32,7 +32,7 @@ module.exports = {
             {
                 path: 'foo',
                 errorCode: 'type.openapi.responseValidation',
-                message: 'foo is not of a type(s) string'
+                message: 'foo should be string'
             }
         ]
     }


### PR DESCRIPTION
Follow up from #161.

This is a breaking change again due to mapping through the underlying validation errors.