### PR TITLE
express-openapi: fix type definitions for ajv error

### DIFF
--- a/packages/express-openapi/index.d.ts
+++ b/packages/express-openapi/index.d.ts
@@ -17,7 +17,7 @@ export interface Args {
     routesIndexFileRegExp?: RegExp;
     docsPath?: string
     errorMiddleware?: express.ErrorRequestHandler,
-    errorTransformer?(openapiError: OpenapiError, jsonschemaError: JsonschemaError): any
+    errorTransformer?(openapiError: OpenapiError, ajvError: AjvError): any
     exposeApiDocs?: boolean
     promiseMode?: boolean
     validateApiDoc?: boolean
@@ -84,16 +84,17 @@ export interface CustomFormats {
     [index: string]: CustomFormatValidator
 }
 
-// Following 2 interfaces are part of jsonschema package.
-interface JsonschemaError {
-    property: string
-    message: string
-    schema: string|IJsonSchema
-    instance: any
-    name: string
-    argument: any
-    stack: string
-    toString(): string
+// The following interface is part of the ajv package.
+interface AjvError {
+    keyword: string;
+    dataPath: string;
+    schemaPath: string;
+    params: object;
+    propertyName?: string;
+    message?: string;
+    schema?: any;
+    parentSchema?: object;
+    data?: any;
 }
 
 interface CustomFormatValidator {


### PR DESCRIPTION
This is to make sure we don't forget to change the type definitions for `express-openapi` when we cascade the ajv changes. Feel free to cherry-pick this commit into your own branch when you bump the versions!