### PR TITLE
openapi-response-validator: now accepts nullable property + test

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -119,7 +119,7 @@ function compileValidators(v, schemas) {
   const validators = {};
 
   Object.keys(schemas).forEach(name => {
-    validators[name] = v.compile(schemas[name]);
+    validators[name] = v.compile(transformOpenAPIV3Definitions(schemas[name]));
   });
 
   return validators;
@@ -167,4 +167,28 @@ function toOpenapiValidationError(error: Ajv.ErrorObject): OpenAPIResponseValida
   }
 
   return validationError;
+}
+
+function recursiveTransformOpenAPIV3Definitions(object) {
+    // Transformations //
+    // OpenAPIV3 nullable
+    if (object.type && object.nullable == true) {
+        object.type = [object.type, "null"];
+        delete object.nullable;
+    }
+
+    Object.keys(object).forEach(attr => {
+        if (typeof object[attr] == 'object') {
+            recursiveTransformOpenAPIV3Definitions(object[attr]);
+        }
+    });
+};
+
+function transformOpenAPIV3Definitions(schema) {
+    if (typeof schema != 'object') {
+        return schema;
+    }
+    const res = {...schema};
+    recursiveTransformOpenAPIV3Definitions(res);
+    return res;
 }

--- a/packages/openapi-response-validator/package-lock.json
+++ b/packages/openapi-response-validator/package-lock.json
@@ -9,10 +9,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
       "integrity": "sha1-JH1SdBENtlNwa1UPzCt5fKKM/Fk=",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "fast-deep-equal": {
@@ -45,7 +45,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     }
   }

--- a/packages/openapi-response-validator/test/data-driven/accept-nullable-properties.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-nullable-properties.js
@@ -1,0 +1,31 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      "200": {
+          description: "Ok",
+          schema: {
+              "type": "object",
+              "properties": {
+                  "msisdn": {
+                      "type": "string"
+                  },
+                  "countryId": {
+                      "type": "string",
+                      "nullable": true
+                  }
+              },
+              "required": [
+                  "msisdn"
+              ]
+          }
+      }
+  },
+
+    definitions: null
+  },
+
+  inputStatusCode: 200,
+  inputResponseBody: {"msisdn":"790000000000","countryId":null},
+
+  expectedValidationError: void 0
+};


### PR DESCRIPTION
test case shows error and fails but shouldn't in openapi v3