### PR TITLE
add a unit test for "file" parameter types

### DIFF
--- a/packages/express-openapi/test/sample-projects/file-upload/api-doc.js
+++ b/packages/express-openapi/test/sample-projects/file-upload/api-doc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  swagger: '2.0',
+
+  host: "test-host",
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  paths: {},
+
+  tags: [
+    {description: 'Drafts', name: 'Drafts'}
+  ]
+};

--- a/packages/express-openapi/test/sample-projects/file-upload/api-routes/fileupload.js
+++ b/packages/express-openapi/test/sample-projects/file-upload/api-routes/fileupload.js
@@ -1,0 +1,52 @@
+module.exports = {
+  post: function(req, res, next) {
+    res.status(200).json({});
+  }
+};
+
+module.exports.post.apiDoc = {
+  summary: "Form file upload. Accepts a form file upload named 'file'.",
+  operationId: "FormDraftFileUpload",
+
+  tags: ["Drafts"],
+  consumes: [
+    "multipart/form-data"
+  ],
+  parameters: [
+    {
+      name: "process_intel",
+      in: "formData",
+      description: "Whether or not to transform intel files.",
+      type: "boolean",
+      default: false
+    },
+    {
+      name: "overwrite",
+      in: "formData",
+      description: "Whether or not to replace an existing file.",
+      type: "boolean",
+      default: true
+    },
+    {
+      name: "basepath",
+      in: "formData",
+      description: "Root directory to place files.",
+      type: "string",
+      default: ""
+    },
+    {
+      name: "file",
+      in: "formData",
+      description: "The file to upload",
+      type: "file"
+    }
+  ],
+  responses: {
+    200: {
+      "description": "OK"
+    },
+    400: {
+      "description": "BAD"
+    }
+  }
+};

--- a/packages/express-openapi/test/sample-projects/file-upload/app.js
+++ b/packages/express-openapi/test/sample-projects/file-upload/app.js
@@ -1,0 +1,26 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  paths: path.resolve(__dirname, 'api-routes')
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  app.listen(port);
+}

--- a/packages/express-openapi/test/sample-projects/file-upload/spec.js
+++ b/packages/express-openapi/test/sample-projects/file-upload/spec.js
@@ -1,0 +1,13 @@
+var app;
+var expect = require('chai').expect;
+var request = require('supertest');
+
+before(function() {
+  app = require('./app.js');
+});
+
+it('should upload a file', function(done) {
+  request(app)
+    .post('/v3/fileupload')
+    .expect(200, {}, done);
+});


### PR DESCRIPTION
`
  1) express-openapisample-projects
       file-upload
         "before all" hook:
     Error: schema is invalid: data.properties['file'].type should be equal to one of the allowed values, data.properties['file'].type should be array, data.properties['file'].type should match some schema in anyOf
      at Ajv.validateSchema (node_modules/ajv/lib/ajv.js:183:16)
      at Ajv._addSchema (node_modules/ajv/lib/ajv.js:312:10)
      at Ajv.compile (node_modules/ajv/lib/ajv.js:112:24)
      at new OpenAPIRequestValidator (node_modules/openapi-request-validator/index.ts:132:49)
      at /Users/troymolsberry/Development/open-api/packages/express-openapi/node_modules/openapi-framework/index.ts:268:42
      at Array.forEach (<anonymous>)
      at /Users/troymolsberry/Development/open-api/packages/express-openapi/node_modules/openapi-framework/index.ts:206:49
      at Array.forEach (<anonymous>)
      at OpenAPIFramework.initialize (node_modules/openapi-framework/index.ts:187:12)
      at Object.initialize (index.ts:90:13)
      at Object.<anonymous> (test/sample-projects/file-upload/app.js:11:9)
      at require (internal/module.js:11:18)
      at Context.<anonymous> (test/sample-projects/file-upload/spec.js:6:9)
`