### PR TITLE
openapi-request-coercer: support to type object coercion

### DIFF
--- a/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request.js
@@ -1,0 +1,38 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'query',
+        type: 'array',
+        name: 'include',
+        items: {
+          type: 'object'
+          // optional format property not passed meaning the default coercer will kick in
+        },
+        required: false
+      },
+      {
+        in: 'query',
+        type: 'object',
+        name: 'query',
+        required: false
+        // optional format property not passed meaning the default coercer will kick in
+      }
+    ]
+  },
+
+  request: {
+    query: {
+      include: [
+        JSON.stringify({ association: 'lines', include: ['status'] }),
+        JSON.stringify({ association: 'people', include: ['hairColor'] })
+      ],
+      query: JSON.stringify({ where: { $status: 2 } })
+    }
+  },
+
+  query: {
+    include: [{ association: 'lines', include: ['status'] }, { association: 'people', include: ['hairColor'] }],
+    query: { where: { $status: 2 } }
+  }
+};


### PR DESCRIPTION
openapi-request-coercer: added initial support for type object coercion using the format property as a strategy setting