### PR TITLE
openapi-request-coercer: add OpenAPI3 support to coercer

### DIFF
--- a/packages/express-openapi/package-lock.json
+++ b/packages/express-openapi/package-lock.json
@@ -319,7 +319,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "punycode": {

--- a/packages/openapi-request-coercer/index.ts
+++ b/packages/openapi-request-coercer/index.ts
@@ -180,20 +180,20 @@ function buildCoercer(args) {
           throw new Error(`${args.loggingKey}nested arrays are not allowed (items was of type array)`);
         }
 
-        var itemsType = (schema.items.schema && schema.items.schema.type) ? schema.items.schema.type : schema.items.type;
+        const itemsType = (schema.items.schema && schema.items.schema.type) ? schema.items.schema.type : schema.items.type;
         itemCoercer = getCoercer(itemsType, strict);
 
         if (itemsType === 'object') {
           if (!args.enableObjectCoercion) {
             disableCoercer = true;
           } else {
-            var itemsFormat = (schema.items.schema) ? schema.items.schema.format : schema.format;
+            const itemsFormat = (schema.items.schema) ? schema.items.schema.format : schema.format;
             itemCoercer = itemCoercer.bind(null, itemsFormat);
           }
         }
 
         if (!disableCoercer) {
-          var collectionFormat = param.collectionFormat;
+          let collectionFormat = param.collectionFormat;
           // OpenAPI 3.0 has replaced collectionFormat with a style property
           // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#style-values
           if (param.style) {

--- a/packages/openapi-request-coercer/test/data-driven/coerce-array-with-style-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-array-with-style-openapi3.js
@@ -1,0 +1,111 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'header',
+        name: 'headercsv',
+        schema: {
+          type: 'array',
+          items: { 
+            schema: { type: 'integer' }
+          },
+        },
+        style: 'simple',
+      },
+
+      {
+        in: 'query',
+        name: 'querycsv',
+        schema: {
+          type: 'array',
+          items: {
+            schema: { type: 'string' },
+          },
+        },
+        style: 'form',
+        explodes: false
+      },
+
+      {
+        in: 'query',
+        name: 'querymulti',
+        schema: {
+          type: 'array',
+          items: {
+            schema: { type: 'string' },
+          },
+        },
+        style: 'form',
+        explodes: true,
+      },
+
+      {
+        in: 'query',
+        name: 'querypipe',
+        schema: {
+          type: 'array',
+          items: {
+            schema: { type: 'string' },
+          },
+        },
+        style: 'pipeDelimited',
+      },
+
+      {
+        in: 'query',
+        name: 'queryspace',
+        schema: {
+          type: 'array',
+          items: {
+            schema: { type: 'string' },
+          },
+        },
+        style: 'spaceDelimited',
+      },
+
+      {
+        in: 'path',
+        name: 'pathcsv',
+        schema: {
+          type: 'array',
+          items: {
+            schema: { type: 'string' },
+          },
+        },
+        style: 'simple',
+      }
+    ]
+  },
+
+  request: {
+    method: 'post',
+    path: '/foo,bar,baz/',
+    headers: {
+      'headercsv': '1,2,3'
+    },
+    params: {
+      pathcsv: 'foo,bar,baz',
+    },
+    query: {
+      querycsv: 'foo,bar',
+      querymulti: ['foo', 'bar'],
+      querypipe: 'pipe|delimited|array',
+      queryspace: 'space delimited array',
+    },
+  },
+
+  headers: {
+    headercsv: [1, 2, 3],
+  },
+
+  params: {
+    pathcsv: ['foo', 'bar', 'baz'],
+  },
+
+  query: {
+    querycsv: ['foo', 'bar'],
+    querymulti: ['foo', 'bar'],
+    querypipe: ['pipe', 'delimited', 'array'],
+    queryspace: ['space', 'delimited', 'array'],
+  },
+};

--- a/packages/openapi-request-coercer/test/data-driven/coerce-boolean-params-invalid-value-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-boolean-params-invalid-value-openapi3.js
@@ -1,0 +1,74 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'path',
+        name: 'path1',
+        schema: {
+          type: 'boolean'
+        }
+      },
+
+      {
+        in: 'path',
+        name: 'path2',
+        schema: {
+          type: 'boolean'
+        },
+		    "x-openapi-coercion-strict": true
+      },
+
+      {
+        in: 'query',
+        name: 'query1',
+        schema: {
+          type: 'boolean'
+        }
+      },
+
+      {
+        in: 'query',
+        name: 'query2',
+        schema: {
+          type: 'boolean'
+        }
+      },
+
+      {
+        in: 'query',
+        name: 'query3',
+        schema: {
+          type: 'boolean'
+        },
+		    "x-openapi-coercion-strict": true
+      }
+    ]
+  },
+
+  request: {
+    path: '/invalid/invalid',
+    params: {
+      path1: 'invalid',
+      path2: 'invalid'
+    },
+    query: {
+      query1: 'true',
+      query2: 'invalid',
+      query3: 'invalid'
+    },
+    headers: null,
+  },
+
+  headers: null,
+
+  params: {
+    path1: true,
+    path2: null,
+  },
+
+  query: {
+    query1: true,
+    query2: true,
+    query3: null
+  }
+};

--- a/packages/openapi-request-coercer/test/data-driven/coerce-boolean-params-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-boolean-params-openapi3.js
@@ -1,0 +1,62 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'path',
+        name: 'path1',
+        schema: {
+          type: 'boolean',
+        },
+      },
+
+      {
+        in: 'path',
+        name: 'path2',
+        schema: {
+          type: 'boolean',
+        },
+      },
+
+      {
+        in: 'query',
+        name: 'query1',
+        schema: {
+          type: 'boolean',
+        },
+      },
+
+      {
+        in: 'query',
+        name: 'query2',
+        schema: {
+          type: 'boolean',
+        },
+      }
+    ]
+  },
+
+  request: {
+    path: '/true/false',
+    params: {
+      path1: true,
+      path2: 'false'
+    },
+    query: {
+      query1: 'true',
+      query2: 'false'
+    },
+    headers: null
+  },
+
+  headers: null,
+
+  params: {
+    path1: true,
+    path2: false
+  },
+
+  query: {
+    query1: true,
+    query2: false
+  }
+};

--- a/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request-openapi3.js
@@ -40,7 +40,14 @@ module.exports = {
   },
 
   query: {
-    include: [{ association: 'lines', include: ['status'] }, { association: 'people', include: ['hairColor'] }],
-    query: { where: { $status: 2 } }
+    include: [
+      { association: 'lines', include: ['status'] },
+      { association: 'people', include: ['hairColor'] }
+    ],
+    query: { 
+      where: { 
+        $status: 2 
+      }
+    }
   }
 };

--- a/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request-openapi3.js
@@ -1,0 +1,46 @@
+module.exports = {
+  args: {
+    enableObjectCoercion: true,
+    parameters: [
+      {
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: {
+            schema: {
+              type: 'object',
+              // optional format property not passed meaning default coercer will kick in
+            },
+          },
+        },
+        name: 'include',
+        required: false
+      },
+      {
+        in: 'query',
+        schema: {
+          type: 'object',
+          // optional format property not passed meaning the default coercer will kick in
+        },
+        name: 'query',
+        required: false
+        // optional format property not passed meaning the default coercer will kick in
+      }
+    ]
+  },
+
+  request: {
+    query: {
+      include: [
+        JSON.stringify({ association: 'lines', include: ['status'] }),
+        JSON.stringify({ association: 'people', include: ['hairColor'] })
+      ],
+      query: JSON.stringify({ where: { $status: 2 } })
+    }
+  },
+
+  query: {
+    include: [{ association: 'lines', include: ['status'] }, { association: 'people', include: ['hairColor'] }],
+    query: { where: { $status: 2 } }
+  }
+};

--- a/packages/openapi-request-coercer/test/data-driven/coerce-params-in-request-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-params-in-request-openapi3.js
@@ -1,0 +1,74 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'header',
+        name: 'X-Foo',
+        schema: {
+          type: 'boolean',
+        },
+      },
+
+      {
+        in: 'path',
+        name: 'path1',
+        schema: {
+          type: 'integer',
+        },
+      },
+
+      {
+        in: 'path',
+        name: 'path2',
+        schema: {
+          type: 'number',
+        },
+      },
+
+      {
+        in: 'query',
+        name: 'foo',
+        schema: {
+          type: 'boolean',
+        },
+      },
+
+      {
+        in: 'query',
+        name: 'boo',
+        schema: {
+          type: 'string',
+        },
+      }
+    ]
+  },
+
+  request: {
+    path: '/5/6.35',
+    params: {
+      path1: '5',
+      path2: '6.35'
+    },
+    query: {
+      foo: 'false',
+      boo: 'asdf'
+    },
+    headers: {
+      'x-foo': 'false'
+    }
+  },
+
+  headers: {
+    'x-foo': false
+  },
+
+  params: {
+    path1: 5,
+    path2: 6.35
+  },
+
+  query: {
+    foo: false,
+    boo: 'asdf'
+  }
+};

--- a/packages/openapi-request-coercer/test/data-driven/handle-strict-extension-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/handle-strict-extension-openapi3.js
@@ -1,0 +1,56 @@
+module.exports = {
+  args: {
+    extensionBase: 'x-foo-coercion',
+    parameters: [
+      {
+        in: 'path',
+        name: 'path0',
+        schema: {
+          type: 'boolean',
+        },
+		    'x-foo-coercion-strict': true
+      },
+
+      {
+        in: 'path',
+        name: 'path1',
+        schema: {
+          type: 'boolean',
+        },
+		    'x-foo-coercion-strict': true
+      },
+
+      {
+        in: 'path',
+        name: 'path2',
+        schema: {
+          type: 'boolean',
+        },
+		    'x-foo-coercion-strict': true
+      }
+    ]
+  },
+
+  request: {
+    path: '/true/TRUE/FALSE',
+    params: {
+      path0: true,
+      path1: 'true',
+      path2: 'false'
+    },
+    query: {
+    },
+    headers: null,
+  },
+
+  headers: null,
+
+  params: {
+    path0: true,
+    path1: true,
+    path2: false,
+  },
+
+  query: {
+  }
+};

--- a/packages/openapi-request-coercer/test/data-driven/ignore-object-params-in-request-when-enableObjectCoercion-is-not-set-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/ignore-object-params-in-request-when-enableObjectCoercion-is-not-set-openapi3.js
@@ -1,0 +1,47 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: { 
+            schema: { 
+              type: 'object',
+              // optional format property not passed meaning the default coercer will kick in
+            } 
+          },
+        },
+        name: 'include',
+        required: false,
+      },
+      {
+        in: 'query',
+        schema: {
+          type: 'object',
+          // optional format property not passed meaning the default coercer will kick in
+        },
+        name: 'query',
+        required: false,        
+      }
+    ]
+  },
+
+  request: {
+    query: {
+      include: [
+        JSON.stringify({ association: 'lines', include: ['status'] }),
+        JSON.stringify({ association: 'people', include: ['hairColor'] })
+      ],
+      query: JSON.stringify({ where: { $status: 2 } })
+    }
+  },
+
+  query: {
+    include: [
+      JSON.stringify({ association: 'lines', include: ['status'] }),
+      JSON.stringify({ association: 'people', include: ['hairColor'] })
+    ],
+    query: JSON.stringify({ where: { $status: 2 } })
+  }
+};

--- a/packages/openapi-request-coercer/test/data-driven/ignore-unkown-types-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/ignore-unkown-types-openapi3.js
@@ -1,0 +1,39 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'path',
+        name: 'path1',
+        schema: {
+          type: 'asdfasdf',
+        },
+      },
+
+      {
+        in: 'path',
+        name: 'path2',
+        schema: {
+          type: 'dddd',
+        },
+      }
+    ]
+  },
+
+  request: {
+    path: '/5/6.35',
+    params: {
+      path1: '5',
+      path2: '6.35'
+    },
+    headers: null
+  },
+
+  headers: null,
+
+  params: {
+    path1: '5',
+    path2: '6.35'
+  },
+
+  query: null
+};

--- a/packages/openapi-request-coercer/test/data-driven/should-pass-through-arrays-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/should-pass-through-arrays-openapi3.js
@@ -1,0 +1,49 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'query',
+        name: 'foo',
+        schema: {
+          type: 'array',
+          items: {
+            schema: {
+              type: 'integer',
+            },
+          },
+        },
+      },
+
+      {
+        in: 'query',
+        name: 'boo',
+        schema: {
+          type: 'array',
+          items: {
+            schema: {
+              type: 'number',
+            },
+          },
+        },
+      }
+    ]
+  },
+
+  request: {
+    path: '/',
+    query: {
+      'foo': ['5', '6'],
+      'boo': '34.2345'
+    },
+    headers: null
+  },
+
+  headers: null,
+
+  params: null,
+
+  query: {
+    foo: [5, 6],
+    boo: [34.2345]
+  }
+};

--- a/packages/openapi-request-coercer/test/data-driven/throw-error-when-array-parameter-has-items-property-of-type-array-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/throw-error-when-array-parameter-has-items-property-of-type-array-openapi3.js
@@ -1,0 +1,30 @@
+module.exports = {
+  constructorError: /openapi-coercion: nested arrays are not allowed \(items was of type array\)/,
+
+  args: {
+    loggingKey: 'openapi-coercion',
+    parameters: [
+      {
+        name: 'foo',
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: {
+            schema: {
+              type: 'array',
+            },
+          },
+        },
+      }
+    ]
+  },
+
+  request: {
+    path: '',
+    headers: null
+  },
+
+  headers: null,
+  params: null,
+  query: null
+};

--- a/packages/openapi-request-coercer/test/data-driven/throw-error-when-array-parameter-has-no-items-property-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/throw-error-when-array-parameter-has-no-items-property-openapi3.js
@@ -1,0 +1,25 @@
+module.exports = {
+  constructorError: /openapi-coercion: items is a required property with type array/,
+
+  args: {
+    loggingKey: 'openapi-coercion',
+    parameters: [
+      {
+        name: 'foo',
+        in: 'query',
+        schema: {
+          type: 'array',
+        },
+      }
+    ]
+  },
+
+  request: {
+    path: '',
+    headers: null
+  },
+
+  headers: null,
+  params: null,
+  query: null
+};


### PR DESCRIPTION
Request validation is failing on any non-string query parameter if OpenAPI 3 specification is used because coercion is not occurring. The [parameter specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject) changed so a schema property now holds most of the type related information for the coercer to work properly.

A second change is the removal of the collectionFormat property from the parameter specification. It was replaced with a combination of `in`, `style` and `explode` properties. This PR also addresses that change.

I tried to write tests mimicking the existing test suite with OpenAPI 3 parameter specifications and added a test to validate the collectionFormat change.