### PR TITLE
fix: Fix OpenAPI v3 response validation for schemas with references

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -13,6 +13,11 @@ export interface OpenAPIResponseValidatorArgs {
   definitions: {
     [definitionName: string]: IJsonSchema,
   };
+  components: {
+    schemas: {
+      [schemaName: string]: IJsonSchema,
+    }
+  };
   errorTransformer?(
     openAPIResponseValidatorValidationError: OpenAPIResponseValidatorError,
     ajvError: Ajv.ErrorObject,
@@ -83,7 +88,7 @@ export default class OpenAPIResponseValidator implements IOpenAPIResponseValidat
       });
     }
 
-    const schemas = getSchemas(args.responses, args.definitions);
+    const schemas = getSchemas(args.responses, args.definitions, args.components);
     this.validators = compileValidators(v, schemas);
   }
 
@@ -125,7 +130,7 @@ function compileValidators(v, schemas) {
   return validators;
 }
 
-function getSchemas(responses, definitions) {
+function getSchemas(responses, definitions, components) {
   const schemas = {};
 
   Object.keys(responses).forEach(name => {
@@ -149,7 +154,8 @@ function getSchemas(responses, definitions) {
       properties: {
         response: schema
       },
-      definitions: definitions || {}
+      definitions: definitions || {},
+      components: components || {}
     };
   });
 

--- a/packages/openapi-response-validator/test/data-driven/accept-openapi3-with-ref-responses.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-openapi3-with-ref-responses.js
@@ -1,0 +1,35 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      200: {
+        description: "Ok",
+        content: {
+          "application/json": {
+            schema: {
+              '$ref': '#/components/schemas/Foo'
+            }
+          }
+        }
+      }
+    },
+    components: {
+      schemas: {
+        Foo: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    },
+  },
+
+  inputStatusCode: 200,
+
+  inputResponseBody: {id: 'asdf'},
+
+  expectedValidationError: void 0
+};


### PR DESCRIPTION
Following discussion in #269, creating this PR.
Fixed an issue with openapi schemas with references.

I believe fix is slightly sloppy, because it mixes v2 and v3 specific fields in code. 
Would be nice to refactor code, so it would be easier to implement specific behaviour for specific version of the schema.