### PR TITLE
express-openapi: Use OpenApi 3.0 servers attribute to build baseUrls

### DIFF
--- a/packages/express-openapi/test/sample-projects/with-servers/api-routes/users.js
+++ b/packages/express-openapi/test/sample-projects/with-servers/api-routes/users.js
@@ -1,0 +1,7 @@
+module.exports = {
+  get: [
+    function(req, res, next) {
+      res.status(200).json([{ name: 'fred' }]);
+    }
+  ]
+};

--- a/packages/express-openapi/test/sample-projects/with-servers/spec.js
+++ b/packages/express-openapi/test/sample-projects/with-servers/spec.js
@@ -1,0 +1,146 @@
+const supertest = require('supertest');
+const express = require('express');
+const openapi = require('../../../');
+const path = require('path');
+
+describe('using servers attribute', function() {
+  const tests = [
+    {
+      name: 'with relative url with variable and enum',
+      servers: [
+        {
+          url: '/{base}',
+          variables: {
+            base: {
+              default: 'v1',
+              enum: ['v1', 'api']
+            }
+          }
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple full urls',
+      servers: [
+        {
+          url: 'https://my.api.io/v1'
+        },
+        {
+          url: 'https://my.proxy.io/api/v1'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/v1/users',
+        '/v1/api-docs',
+        '/api/v1/api-docs'
+      ]
+    },
+    {
+      name: 'with multiple full urls with the same path',
+      servers: [
+        { url: 'http://my.api.io/v1' },
+        { url: 'https://my.api.io/v1' }
+      ],
+      expectedPaths: ['/v1/users']
+    },
+    {
+      name: 'with multiple servers both relative and full',
+      servers: [
+        {
+          url: '/v1'
+        },
+        {
+          url: 'https://my.server.io/api'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple servers that have relative paths',
+      servers: [{ url: '/v1' }, { url: '/api' }],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with relative url that has variables',
+      servers: [{ url: '/{base}', variables: { base: { default: 'api' } } }],
+      expectedPaths: [
+        '/api/users',
+        '/foo/users',
+        '/me/users',
+        '/api/api-docs',
+        '/wiki/api-docs'
+      ]
+    },
+    {
+      name: 'with single full url',
+      servers: [{ url: 'http://my.api.io/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with single relative url',
+      servers: [{ url: '/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with variable in host part of the url',
+      servers: [
+        { url: 'http://{host}/v1', variables: { host: { default: 'foo.com' } } }
+      ],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    }
+  ];
+
+  for (let test of tests) {
+    describe(test.name, function() {
+      let request;
+      before(function() {
+        const app = express();
+        openapi.initialize({
+          app,
+          apiDoc: generateOpenApiDocWithServers(test.servers),
+          paths: path.resolve(__dirname, 'api-routes')
+        });
+        request = supertest(app);
+      });
+      for (let i of test.expectedPaths) {
+        it(`should have route ${i}`, function(done) {
+          request
+            .get(i)
+            .expect(200)
+            .end(function(error) {
+              done(error);
+            });
+        });
+      }
+    });
+  }
+});
+
+function generateOpenApiDocWithServers(servers) {
+  return {
+    openapi: '3.0.0',
+    info: {
+      title: 'test',
+      version: '1.0'
+    },
+    paths: {},
+    servers
+  };
+}

--- a/packages/koa-openapi/test/sample-projects/with-servers/api-routes/users.js
+++ b/packages/koa-openapi/test/sample-projects/with-servers/api-routes/users.js
@@ -1,0 +1,10 @@
+module.exports = {
+  get: function get(ctx) {
+    ctx.status = 200;
+    ctx.body = {
+      id: ctx.params.id,
+      name: ctx.query.name,
+      age: ctx.query.age
+    };
+  }
+};

--- a/packages/koa-openapi/test/sample-projects/with-servers/spec.js
+++ b/packages/koa-openapi/test/sample-projects/with-servers/spec.js
@@ -1,0 +1,164 @@
+const supertest = require('supertest');
+const Koa = require('koa');
+const Router = require('koa-router');
+const openapi = require('../../../');
+const path = require('path');
+const http = require('http');
+
+describe('using servers attribute', function() {
+  const tests = [
+    {
+      name: 'with relative url with variable and enum',
+      servers: [
+        {
+          url: '/{base}',
+          variables: {
+            base: {
+              default: 'v1',
+              enum: ['v1', 'api']
+            }
+          }
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple full urls',
+      servers: [
+        {
+          url: 'https://my.api.io/v1'
+        },
+        {
+          url: 'https://my.proxy.io/api/v1'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/v1/users',
+        '/v1/api-docs',
+        '/api/v1/api-docs'
+      ]
+    },
+    {
+      name: 'with multiple full urls with the same path',
+      servers: [
+        { url: 'http://my.api.io/v1' },
+        { url: 'https://my.api.io/v1' }
+      ],
+      expectedPaths: ['/v1/users']
+    },
+    {
+      name: 'with multiple servers both relative and full',
+      servers: [
+        {
+          url: '/v1'
+        },
+        {
+          url: 'https://my.server.io/api'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple servers that have relative paths',
+      servers: [{ url: '/v1' }, { url: '/api' }],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with relative url that has variables',
+      servers: [{ url: '/{base}', variables: { base: { default: 'api' } } }],
+      expectedPaths: [
+        '/api/users',
+        '/foo/users',
+        '/me/users',
+        '/api/api-docs',
+        '/wiki/api-docs'
+      ]
+    },
+    {
+      name: 'with single full url',
+      servers: [{ url: 'http://my.api.io/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with single relative url',
+      servers: [{ url: '/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with variable in host part of the url',
+      servers: [
+        { url: 'http://{host}/v1', variables: { host: { default: 'foo.com' } } }
+      ],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    }
+  ];
+
+  for (let test of tests) {
+    describe(test.name, function() {
+      let request;
+      before(function() {
+        const app = new Koa();
+        const router = new Router();
+        app.use(async (ctx, next) => {
+          try {
+            await next();
+          } catch (e) {
+            console.log(e);
+            ctx.status = e.status;
+            if (e.errors) {
+              ctx.body = {
+                status: e.status || 500,
+                errors: e.errors
+              };
+            }
+          }
+        });
+        openapi.initialize({
+          apiDoc: generateOpenApiDocWithServers(test.servers),
+          paths: path.resolve(__dirname, 'api-routes'),
+          router
+        });
+        app.use(router.routes());
+        request = supertest(http.createServer(app.callback()));
+      });
+      for (let i of test.expectedPaths) {
+        it(`should have route ${i}`, function(done) {
+          request
+            .get(i)
+            .expect(200)
+            .end(function(error) {
+              done(error);
+            });
+        });
+      }
+    });
+  }
+});
+
+function generateOpenApiDocWithServers(servers) {
+  return {
+    openapi: '3.0.0',
+    info: {
+      title: 'test',
+      version: '1.0'
+    },
+    paths: {},
+    servers
+  };
+}

--- a/packages/openapi-framework/src/BasePath.ts
+++ b/packages/openapi-framework/src/BasePath.ts
@@ -1,0 +1,27 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { URL } from 'url';
+export default class BasePath {
+  public readonly variables: { [key: string]: { enum: string[] } } = {};
+  public readonly path: string = '';
+
+  constructor(server: OpenAPIV3.ServerObject) {
+    // break the url into parts
+    // baseUrl param added to make the parsing of relative paths go well
+    const serverUrl = new URL(server.url, 'http://localhost');
+    let urlPath = decodeURI(serverUrl.pathname).replace(/\/$/, '');
+    if (/{\w+}/.test(urlPath)) {
+      // has variable that we need to check out
+      urlPath = urlPath.replace(/{(\w+)}/g, (substring, p1) => `:${p1}`);
+    }
+    this.path = urlPath;
+    for (const variable in server.variables) {
+      if (server.variables.hasOwnProperty(variable)) {
+        this.variables[variable] = { enum: server.variables[variable].enum };
+      }
+    }
+  }
+
+  public hasVariables() {
+    return Object.keys(this.variables).length > 0;
+  }
+}

--- a/packages/openapi-framework/src/types.ts
+++ b/packages/openapi-framework/src/types.ts
@@ -7,7 +7,7 @@ import {
   SecurityHandlers
 } from 'openapi-security-handler';
 import { IJsonSchema, OpenAPI, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
-
+import BasePath from './BasePath';
 export {
   OpenAPIFrameworkArgs,
   OpenAPIFrameworkConstructorArgs,
@@ -69,13 +69,13 @@ interface OpenAPIFrameworkArgs {
 }
 
 export interface OpenAPIFrameworkAPIContext {
-  basePath: string;
+  basePaths: BasePath[];
   // TODO fill this out
   getApiDoc(): any;
 }
 
 export interface OpenAPIFrameworkPathContext {
-  basePath: string;
+  basePaths: BasePath[];
   // TODO fill this out
   getApiDoc(): any;
   getPathDoc(): any;
@@ -85,7 +85,7 @@ export interface OpenAPIFrameworkOperationContext {
   additionalFeatures: any[];
   allowsFeatures: boolean;
   apiDoc: any;
-  basePath: string;
+  basePaths: BasePath[];
   consumes: string[];
   features: {
     coercer?: IOpenAPIRequestCoercer;

--- a/packages/openapi-framework/src/util.ts
+++ b/packages/openapi-framework/src/util.ts
@@ -1,3 +1,6 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { URL } from 'url';
+import BasePath from './BasePath';
 import { IOpenAPIFramework } from './types';
 const difunc = require('difunc');
 const fs = require('fs');
@@ -346,4 +349,18 @@ export function withNoDuplicates(arr) {
   }
 
   return parameters;
+}
+
+export function getBasePathsFromServers(
+  servers: OpenAPIV3.ServerObject[]
+): BasePath[] {
+  if (!servers) {
+    return [new BasePath({ url: '' })];
+  }
+  const basePathsMap: { [key: string]: BasePath } = {};
+  for (const server of servers) {
+    const basePath = new BasePath(server);
+    basePathsMap[basePath.path] = basePath;
+  }
+  return Object.keys(basePathsMap).map(key => basePathsMap[key]);
 }

--- a/packages/openapi-framework/test/sample-projects/base-paths/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/base-paths/spec.ts
@@ -1,0 +1,110 @@
+import { assert } from 'chai';
+import * as path from 'path';
+import OpenapiFramework from '../../../';
+import { initialize } from '../../../../koa-openapi/dist';
+
+describe('using servers attribute', () => {
+  describe('with no defined servers', () => {
+    let framework;
+
+    before(() => {
+      framework = new OpenapiFramework(generateOpenApiDocArgsWithServers());
+    });
+    it('should have a single baseUrl with a path of empty string', () => {
+      const testFn = ctx => {
+        assert.equal(ctx.basePaths.length, 1);
+        assert.equal(ctx.basePaths[0].path, '');
+        assert.isFalse(ctx.basePaths[0].hasVariables());
+      };
+      framework.initialize({
+        visitApi: testFn,
+        visitOperation: testFn,
+        visitPath: testFn
+      });
+    });
+  });
+
+  describe('with variable and enum', () => {
+    const servers = [
+      {
+        url: '/{base}',
+        variables: {
+          base: {
+            default: 'v1',
+            enum: ['v1', 'api']
+          }
+        }
+      }
+    ];
+
+    let framework;
+
+    before(() => {
+      framework = new OpenapiFramework(
+        generateOpenApiDocArgsWithServers(servers)
+      );
+    });
+
+    it('should have have enum attribute to the basePath', () => {
+      const testFn = ctx => {
+        assert.equal(ctx.basePaths.length, 1);
+        assert.equal(ctx.basePaths[0].path, '/:base');
+        assert.isTrue(ctx.basePaths[0].hasVariables());
+        assert.deepEqual(ctx.basePaths[0].variables.base.enum, ['v1', 'api']);
+      };
+      framework.initialize({
+        visitApi: testFn,
+        visitOperation: testFn,
+        visitPath: testFn
+      });
+    });
+  });
+  describe('with multiple urls', () => {
+    const servers = [
+      {
+        url: 'http://my.api.io/v1'
+      },
+      {
+        url: '/api/v1'
+      },
+      { url: 'https://my.api.io/api/v1' }
+    ];
+    let framework;
+    before(() => {
+      framework = new OpenapiFramework(
+        generateOpenApiDocArgsWithServers(servers)
+      );
+    });
+    it('should have each unique base path present', () => {
+      const testFn = ctx => {
+        assert.equal(ctx.basePaths.length, 2);
+        assert.deepEqual(ctx.basePaths.map(basePath => basePath.path), [
+          '/v1',
+          '/api/v1'
+        ]);
+      };
+      framework.initialize({
+        visitApi: testFn,
+        visitOperation: testFn,
+        visitPath: testFn
+      });
+    });
+  });
+});
+
+function generateOpenApiDocArgsWithServers(servers?) {
+  return {
+    apiDoc: {
+      openapi: '3.0.0',
+      info: {
+        title: 'test',
+        version: '1.0'
+      },
+      paths: {},
+      servers
+    },
+    featureType: 'middleware',
+    name: 'some-framework',
+    paths: path.resolve(__dirname, 'paths')
+  };
+}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-doc-default-parameters-disabled/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-doc-default-parameters-disabled/spec.ts
@@ -42,7 +42,8 @@ describe(path.basename(__dirname), () => {
       },
 
       visitPath(ctx) {
-        expect(ctx.basePath).to.equal('');
+        expect(ctx.basePaths.length).to.equal(1);
+        expect(ctx.basePaths[0].path).to.equal('');
         expect(ctx.getPathDoc()).to.eql({
           parameters: [
             {


### PR DESCRIPTION
Closes #274

Turns out I didn't really need  to touch `openapi-framework` at all.  A lot of what I wanted to do was rather express specific, and the ctx objects already expose the apiDoc. 