### PR TITLE
openapi-request-validator: support refs in requestBody schema to both…

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -135,6 +135,9 @@ export default class OpenAPIRequestValidator
         });
       } else if (bodySchema) {
         bodyValidationSchema.definitions = args.schemas;
+        bodyValidationSchema.components = {
+          schemas: args.schemas
+        };
       }
     }
 
@@ -150,7 +153,9 @@ export default class OpenAPIRequestValidator
         this.requestBodyValidators[mediaTypeKey] = v.compile({
           properties: {
             body: args.requestBody.content[mediaTypeKey].schema
-          }
+          },
+          definitions: args.schemas || {},
+          components: {schemas: args.schemas}
         });
       }
     }

--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -155,7 +155,7 @@ export default class OpenAPIRequestValidator
             body: args.requestBody.content[mediaTypeKey].schema
           },
           definitions: args.schemas || {},
-          components: {schemas: args.schemas}
+          components: { schemas: args.schemas }
         });
       }
     }

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-components-ref.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-components-ref.js
@@ -1,0 +1,33 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Test1'
+          }
+        }
+      }
+    },
+    schemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        required: ['foo']
+      }
+    }
+  },
+  request: {
+    body: {
+      foo: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-definitions-ref.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-definitions-ref.js
@@ -1,0 +1,33 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/definitions/Test1'
+          }
+        }
+      }
+    },
+    schemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        required: ['foo']
+      }
+    }
+  },
+  request: {
+    body: {
+      foo: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-schema-components-ref-in-body.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-schema-components-ref-in-body.js
@@ -1,0 +1,29 @@
+module.exports = {
+  validateArgs: {
+    parameters: [
+      {
+        in: 'body',
+        name: 'foo',
+        required: true,
+        schema: {
+          $ref: '#/components/schemas/Test1'
+        }
+      }
+    ],
+    schemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        required: ['foo']
+      }
+    }
+  },
+  request: {
+    body: {
+      foo: 'asdf'
+    }
+  }
+};


### PR DESCRIPTION
… definitions and components.schemas