### PR TITLE
openapi-response-validator: Allow different content types for OpenAPI 3.0 response definitions

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -151,9 +151,9 @@ function getSchemas(responses, definitions, components) {
       ? typeof response.schema === 'object'
         ? response.schema
         : typeof response.content === 'object' &&
-          typeof response.content['application/json'] === 'object' &&
-          typeof response.content['application/json'].schema === 'object'
-        ? response.content['application/json'].schema
+          typeof response.content[Object.keys(response.content)[0]] === 'object' &&
+          typeof response.content[Object.keys(response.content)[0]].schema === 'object'
+        ? response.content[Object.keys(response.content)[0]].schema
         : { type: 'null' }
       : { type: 'null' };
 

--- a/packages/openapi-response-validator/test/data-driven/accept-openapi3-responses-different-content-types.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-openapi3-responses-different-content-types.js
@@ -1,0 +1,23 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      200: {
+        description: 'Ok',
+        content: {
+          'text/markdown': {
+            schema: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    },
+    definitions: null
+  },
+
+  inputStatusCode: 200,
+
+  inputResponseBody: '# documentation\n',
+
+  expectedValidationError: void 0
+};


### PR DESCRIPTION
Closes #290.