### PR TITLE
openapi-framework: OpenApi v3 servers support

### DIFF
--- a/packages/openapi-framework/src/BasePath.ts
+++ b/packages/openapi-framework/src/BasePath.ts
@@ -1,0 +1,27 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { URL } from 'url';
+export default class BasePath {
+  public readonly variables: { [key: string]: { enum: string[] } } = {};
+  public readonly path: string = '';
+
+  constructor(server: OpenAPIV3.ServerObject) {
+    // break the url into parts
+    // baseUrl param added to make the parsing of relative paths go well
+    const serverUrl = new URL(server.url, 'http://localhost');
+    let urlPath = decodeURI(serverUrl.pathname).replace(/\/$/, '');
+    if (/{\w+}/.test(urlPath)) {
+      // has variable that we need to check out
+      urlPath = urlPath.replace(/{(\w+)}/g, (substring, p1) => `:${p1}`);
+    }
+    this.path = urlPath;
+    for (const variable in server.variables) {
+      if (server.variables.hasOwnProperty(variable)) {
+        this.variables[variable] = { enum: server.variables[variable].enum };
+      }
+    }
+  }
+
+  public hasVariables() {
+    return Object.keys(this.variables).length > 0;
+  }
+}

--- a/packages/openapi-framework/src/types.ts
+++ b/packages/openapi-framework/src/types.ts
@@ -7,7 +7,7 @@ import {
   SecurityHandlers
 } from 'openapi-security-handler';
 import { IJsonSchema, OpenAPI, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
-
+import BasePath from './BasePath';
 export {
   OpenAPIFrameworkArgs,
   OpenAPIFrameworkConstructorArgs,
@@ -69,13 +69,13 @@ interface OpenAPIFrameworkArgs {
 }
 
 export interface OpenAPIFrameworkAPIContext {
-  basePath: string;
+  basePaths: BasePath[];
   // TODO fill this out
   getApiDoc(): any;
 }
 
 export interface OpenAPIFrameworkPathContext {
-  basePath: string;
+  basePaths: BasePath[];
   // TODO fill this out
   getApiDoc(): any;
   getPathDoc(): any;
@@ -85,7 +85,7 @@ export interface OpenAPIFrameworkOperationContext {
   additionalFeatures: any[];
   allowsFeatures: boolean;
   apiDoc: any;
-  basePath: string;
+  basePaths: BasePath[];
   consumes: string[];
   features: {
     coercer?: IOpenAPIRequestCoercer;

--- a/packages/openapi-framework/src/util.ts
+++ b/packages/openapi-framework/src/util.ts
@@ -1,3 +1,6 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { URL } from 'url';
+import BasePath from './BasePath';
 import { IOpenAPIFramework } from './types';
 const difunc = require('difunc');
 const fs = require('fs');
@@ -346,4 +349,18 @@ export function withNoDuplicates(arr) {
   }
 
   return parameters;
+}
+
+export function getBasePathsFromServers(
+  servers: OpenAPIV3.ServerObject[]
+): BasePath[] {
+  if (!servers) {
+    return [new BasePath({ url: '' })];
+  }
+  const basePathsMap: { [key: string]: BasePath } = {};
+  for (const server of servers) {
+    const basePath = new BasePath(server);
+    basePathsMap[basePath.path] = basePath;
+  }
+  return Object.keys(basePathsMap).map(key => basePathsMap[key]);
 }

--- a/packages/openapi-framework/test/sample-projects/base-paths/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/base-paths/spec.ts
@@ -1,0 +1,109 @@
+import { assert } from 'chai';
+import * as path from 'path';
+import OpenapiFramework from '../../../';
+
+describe('using servers attribute', () => {
+  describe('with no defined servers', () => {
+    let framework;
+
+    before(() => {
+      framework = new OpenapiFramework(generateOpenApiDocArgsWithServers());
+    });
+    it('should have a single baseUrl with a path of empty string', () => {
+      const testFn = ctx => {
+        assert.equal(ctx.basePaths.length, 1);
+        assert.equal(ctx.basePaths[0].path, '');
+        assert.isFalse(ctx.basePaths[0].hasVariables());
+      };
+      framework.initialize({
+        visitApi: testFn,
+        visitOperation: testFn,
+        visitPath: testFn
+      });
+    });
+  });
+
+  describe('with variable and enum', () => {
+    const servers = [
+      {
+        url: '/{base}',
+        variables: {
+          base: {
+            default: 'v1',
+            enum: ['v1', 'api']
+          }
+        }
+      }
+    ];
+
+    let framework;
+
+    before(() => {
+      framework = new OpenapiFramework(
+        generateOpenApiDocArgsWithServers(servers)
+      );
+    });
+
+    it('should have have enum attribute to the basePath', () => {
+      const testFn = ctx => {
+        assert.equal(ctx.basePaths.length, 1);
+        assert.equal(ctx.basePaths[0].path, '/:base');
+        assert.isTrue(ctx.basePaths[0].hasVariables());
+        assert.deepEqual(ctx.basePaths[0].variables.base.enum, ['v1', 'api']);
+      };
+      framework.initialize({
+        visitApi: testFn,
+        visitOperation: testFn,
+        visitPath: testFn
+      });
+    });
+  });
+  describe('with multiple urls', () => {
+    const servers = [
+      {
+        url: 'http://my.api.io/v1'
+      },
+      {
+        url: '/api/v1'
+      },
+      { url: 'https://my.api.io/api/v1' }
+    ];
+    let framework;
+    before(() => {
+      framework = new OpenapiFramework(
+        generateOpenApiDocArgsWithServers(servers)
+      );
+    });
+    it('should have each unique base path present', () => {
+      const testFn = ctx => {
+        assert.equal(ctx.basePaths.length, 2);
+        assert.deepEqual(ctx.basePaths.map(basePath => basePath.path), [
+          '/v1',
+          '/api/v1'
+        ]);
+      };
+      framework.initialize({
+        visitApi: testFn,
+        visitOperation: testFn,
+        visitPath: testFn
+      });
+    });
+  });
+});
+
+function generateOpenApiDocArgsWithServers(servers?) {
+  return {
+    apiDoc: {
+      openapi: '3.0.0',
+      info: {
+        title: 'test',
+        version: '1.0'
+      },
+      paths: {},
+      servers
+    },
+    featureType: 'middleware',
+    name: 'some-framework',
+    paths: path.resolve(__dirname, 'paths')
+  };
+}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-doc-default-parameters-disabled/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-doc-default-parameters-disabled/spec.ts
@@ -42,7 +42,8 @@ describe(path.basename(__dirname), () => {
       },
 
       visitPath(ctx) {
-        expect(ctx.basePath).to.equal('');
+        expect(ctx.basePaths.length).to.equal(1);
+        expect(ctx.basePaths[0].path).to.equal('');
         expect(ctx.getPathDoc()).to.eql({
           parameters: [
             {


### PR DESCRIPTION
OpenAPI v3 support for openapi-framework.  Note that I'm replacing basePath with basePaths so this will be a breaking change.

After this is published I can make the `express-openapi` and `koa-openapi` pull requests.