### PR TITLE
Express koa openapiv3 servers

### DIFF
--- a/packages/express-openapi/package-lock.json
+++ b/packages/express-openapi/package-lock.json
@@ -126,6 +126,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "difunc": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/difunc/-/difunc-0.0.4.tgz",
@@ -197,9 +202,9 @@
       "integrity": "sha1-QdN/SV/MrMBaR3jWboMCTCkro/8="
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -240,9 +245,9 @@
       }
     },
     "openapi-framework": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/openapi-framework/-/openapi-framework-0.16.0.tgz",
-      "integrity": "sha512-9REEGVfZwWVNDuXfJcl2HKyLCOYVlVHec1wwYzVifGAP9q/40vWHB2D4YNhkODiY/9uYgpZEYPi6XsARd1VwJA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-framework/-/openapi-framework-0.17.0.tgz",
+      "integrity": "sha512-hI+kxSP/fNKqwo03zU8KFSI4w2/ez8G9D4hf7t0tCJsVCutssC+prh/8EEtrqNfr2aSWtHymnLkWpLEAkPtViQ==",
       "requires": {
         "difunc": "0.0.4",
         "fs-routes": "2.0.0",
@@ -251,8 +256,8 @@
         "js-yaml": "^3.10.0",
         "openapi-default-setter": "2.0.3",
         "openapi-request-coercer": "2.2.0",
-        "openapi-request-validator": "3.2.0",
-        "openapi-response-validator": "3.5.0",
+        "openapi-request-validator": "3.3.0",
+        "openapi-response-validator": "3.6.0",
         "openapi-schema-validator": "3.0.2",
         "openapi-security-handler": "2.0.3",
         "openapi-types": "^1.3.1"
@@ -275,19 +280,20 @@
       }
     },
     "openapi-request-validator": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-3.2.0.tgz",
-      "integrity": "sha512-C+S9OnHakXMigQ8S90Qb+Qz2AAlJ06wmgcpEYk2SlAzNUw5AwRl+z7TjMCLjmSgkax7IAkFO5DUsoDwvG+ahBg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-3.3.0.tgz",
+      "integrity": "sha512-nASTLltXHqYVV/VU28ZWzXu6/RmQ9/QDUJvvPWLsLB5NJYgB5K20lL7nedWrJ9VAgKh93QIYGHbhH0Wzi5/Hug==",
       "requires": {
         "ajv": "^6.5.4",
+        "content-type": "^1.0.4",
         "openapi-jsonschema-parameters": "^1.0.3",
         "openapi-types": "^1.3.1"
       }
     },
     "openapi-response-validator": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-3.5.0.tgz",
-      "integrity": "sha512-vablLK8F0x3eQLCjxv1fu7RwgamQh0aA0a948XYVzJBrnrHFE8D/iBn2qBIPhYKvwkxdqB0e8coXOSOrT3vsUw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-3.6.0.tgz",
+      "integrity": "sha512-TUBWmA5ZT29uW4I8mtBTrJZ41Hql+nOEASakS1/XFPSHP/FuT1Nm1s1RGsj1WG69nsyxfp62gpGkPbCLGXXddw==",
       "requires": {
         "ajv": "^6.5.4",
         "openapi-types": "^1.3.1"
@@ -319,7 +325,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "punycode": {
@@ -329,7 +335,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "swagger-schema-official": {

--- a/packages/express-openapi/package.json
+++ b/packages/express-openapi/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/kogosoftwarellc/open-api/tree/master/packages/express-openapi#readme",
   "dependencies": {
     "express-normalize-query-params-middleware": "^0.5.0",
-    "openapi-framework": "0.16.0",
+    "openapi-framework": "0.17.0",
     "openapi-types": "^1.3.2"
   },
   "devDependencies": {

--- a/packages/express-openapi/test/sample-projects/with-servers/api-routes/users.js
+++ b/packages/express-openapi/test/sample-projects/with-servers/api-routes/users.js
@@ -1,0 +1,7 @@
+module.exports = {
+  get: [
+    function(req, res, next) {
+      res.status(200).json([{ name: 'fred' }]);
+    }
+  ]
+};

--- a/packages/express-openapi/test/sample-projects/with-servers/spec.js
+++ b/packages/express-openapi/test/sample-projects/with-servers/spec.js
@@ -1,0 +1,146 @@
+const supertest = require('supertest');
+const express = require('express');
+const openapi = require('../../../');
+const path = require('path');
+
+describe('using servers attribute', function() {
+  const tests = [
+    {
+      name: 'with relative url with variable and enum',
+      servers: [
+        {
+          url: '/{base}',
+          variables: {
+            base: {
+              default: 'v1',
+              enum: ['v1', 'api']
+            }
+          }
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple full urls',
+      servers: [
+        {
+          url: 'https://my.api.io/v1'
+        },
+        {
+          url: 'https://my.proxy.io/api/v1'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/v1/users',
+        '/v1/api-docs',
+        '/api/v1/api-docs'
+      ]
+    },
+    {
+      name: 'with multiple full urls with the same path',
+      servers: [
+        { url: 'http://my.api.io/v1' },
+        { url: 'https://my.api.io/v1' }
+      ],
+      expectedPaths: ['/v1/users']
+    },
+    {
+      name: 'with multiple servers both relative and full',
+      servers: [
+        {
+          url: '/v1'
+        },
+        {
+          url: 'https://my.server.io/api'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple servers that have relative paths',
+      servers: [{ url: '/v1' }, { url: '/api' }],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with relative url that has variables',
+      servers: [{ url: '/{base}', variables: { base: { default: 'api' } } }],
+      expectedPaths: [
+        '/api/users',
+        '/foo/users',
+        '/me/users',
+        '/api/api-docs',
+        '/wiki/api-docs'
+      ]
+    },
+    {
+      name: 'with single full url',
+      servers: [{ url: 'http://my.api.io/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with single relative url',
+      servers: [{ url: '/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with variable in host part of the url',
+      servers: [
+        { url: 'http://{host}/v1', variables: { host: { default: 'foo.com' } } }
+      ],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    }
+  ];
+
+  for (let test of tests) {
+    describe(test.name, function() {
+      let request;
+      before(function() {
+        const app = express();
+        openapi.initialize({
+          app,
+          apiDoc: generateOpenApiDocWithServers(test.servers),
+          paths: path.resolve(__dirname, 'api-routes')
+        });
+        request = supertest(app);
+      });
+      for (let i of test.expectedPaths) {
+        it(`should have route ${i}`, function(done) {
+          request
+            .get(i)
+            .expect(200)
+            .end(function(error) {
+              done(error);
+            });
+        });
+      }
+    });
+  }
+});
+
+function generateOpenApiDocWithServers(servers) {
+  return {
+    openapi: '3.0.0',
+    info: {
+      title: 'test',
+      version: '1.0'
+    },
+    paths: {},
+    servers
+  };
+}

--- a/packages/koa-openapi/package-lock.json
+++ b/packages/koa-openapi/package-lock.json
@@ -236,8 +236,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookies": {
       "version": "0.7.2",
@@ -428,9 +427,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -631,9 +630,9 @@
       }
     },
     "openapi-framework": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/openapi-framework/-/openapi-framework-0.16.0.tgz",
-      "integrity": "sha512-9REEGVfZwWVNDuXfJcl2HKyLCOYVlVHec1wwYzVifGAP9q/40vWHB2D4YNhkODiY/9uYgpZEYPi6XsARd1VwJA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-framework/-/openapi-framework-0.17.0.tgz",
+      "integrity": "sha512-hI+kxSP/fNKqwo03zU8KFSI4w2/ez8G9D4hf7t0tCJsVCutssC+prh/8EEtrqNfr2aSWtHymnLkWpLEAkPtViQ==",
       "requires": {
         "difunc": "0.0.4",
         "fs-routes": "2.0.0",
@@ -642,8 +641,8 @@
         "js-yaml": "^3.10.0",
         "openapi-default-setter": "2.0.3",
         "openapi-request-coercer": "2.2.0",
-        "openapi-request-validator": "3.2.0",
-        "openapi-response-validator": "3.5.0",
+        "openapi-request-validator": "3.3.0",
+        "openapi-response-validator": "3.6.0",
         "openapi-schema-validator": "3.0.2",
         "openapi-security-handler": "2.0.3",
         "openapi-types": "^1.3.1"
@@ -666,19 +665,20 @@
       }
     },
     "openapi-request-validator": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-3.2.0.tgz",
-      "integrity": "sha512-C+S9OnHakXMigQ8S90Qb+Qz2AAlJ06wmgcpEYk2SlAzNUw5AwRl+z7TjMCLjmSgkax7IAkFO5DUsoDwvG+ahBg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-3.3.0.tgz",
+      "integrity": "sha512-nASTLltXHqYVV/VU28ZWzXu6/RmQ9/QDUJvvPWLsLB5NJYgB5K20lL7nedWrJ9VAgKh93QIYGHbhH0Wzi5/Hug==",
       "requires": {
         "ajv": "^6.5.4",
+        "content-type": "^1.0.4",
         "openapi-jsonschema-parameters": "^1.0.3",
         "openapi-types": "^1.3.1"
       }
     },
     "openapi-response-validator": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-3.5.0.tgz",
-      "integrity": "sha512-vablLK8F0x3eQLCjxv1fu7RwgamQh0aA0a948XYVzJBrnrHFE8D/iBn2qBIPhYKvwkxdqB0e8coXOSOrT3vsUw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-3.6.0.tgz",
+      "integrity": "sha512-TUBWmA5ZT29uW4I8mtBTrJZ41Hql+nOEASakS1/XFPSHP/FuT1Nm1s1RGsj1WG69nsyxfp62gpGkPbCLGXXddw==",
       "requires": {
         "ajv": "^6.5.4",
         "openapi-types": "^1.3.1"
@@ -716,7 +716,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-to-regexp": {
@@ -779,7 +779,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "statuses": {

--- a/packages/koa-openapi/package.json
+++ b/packages/koa-openapi/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/kogosoftwarellc/open-api/tree/master/packages/koa-openapi#readme",
   "dependencies": {
-    "openapi-framework": "0.16.0"
+    "openapi-framework": "0.17.0"
   },
   "devDependencies": {
     "@types/es6-shim": "^0.31.37",

--- a/packages/koa-openapi/test/sample-projects/with-servers/api-routes/users.js
+++ b/packages/koa-openapi/test/sample-projects/with-servers/api-routes/users.js
@@ -1,0 +1,10 @@
+module.exports = {
+  get: function get(ctx) {
+    ctx.status = 200;
+    ctx.body = {
+      id: ctx.params.id,
+      name: ctx.query.name,
+      age: ctx.query.age
+    };
+  }
+};

--- a/packages/koa-openapi/test/sample-projects/with-servers/spec.js
+++ b/packages/koa-openapi/test/sample-projects/with-servers/spec.js
@@ -1,0 +1,164 @@
+const supertest = require('supertest');
+const Koa = require('koa');
+const Router = require('koa-router');
+const openapi = require('../../../');
+const path = require('path');
+const http = require('http');
+
+describe('using servers attribute', function() {
+  const tests = [
+    {
+      name: 'with relative url with variable and enum',
+      servers: [
+        {
+          url: '/{base}',
+          variables: {
+            base: {
+              default: 'v1',
+              enum: ['v1', 'api']
+            }
+          }
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple full urls',
+      servers: [
+        {
+          url: 'https://my.api.io/v1'
+        },
+        {
+          url: 'https://my.proxy.io/api/v1'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/v1/users',
+        '/v1/api-docs',
+        '/api/v1/api-docs'
+      ]
+    },
+    {
+      name: 'with multiple full urls with the same path',
+      servers: [
+        { url: 'http://my.api.io/v1' },
+        { url: 'https://my.api.io/v1' }
+      ],
+      expectedPaths: ['/v1/users']
+    },
+    {
+      name: 'with multiple servers both relative and full',
+      servers: [
+        {
+          url: '/v1'
+        },
+        {
+          url: 'https://my.server.io/api'
+        }
+      ],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with  multiple servers that have relative paths',
+      servers: [{ url: '/v1' }, { url: '/api' }],
+      expectedPaths: [
+        '/v1/users',
+        '/api/users',
+        '/v1/api-docs',
+        '/api/api-docs'
+      ]
+    },
+    {
+      name: 'with relative url that has variables',
+      servers: [{ url: '/{base}', variables: { base: { default: 'api' } } }],
+      expectedPaths: [
+        '/api/users',
+        '/foo/users',
+        '/me/users',
+        '/api/api-docs',
+        '/wiki/api-docs'
+      ]
+    },
+    {
+      name: 'with single full url',
+      servers: [{ url: 'http://my.api.io/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with single relative url',
+      servers: [{ url: '/v1' }],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    },
+    {
+      name: 'with variable in host part of the url',
+      servers: [
+        { url: 'http://{host}/v1', variables: { host: { default: 'foo.com' } } }
+      ],
+      expectedPaths: ['/v1/users', '/v1/api-docs']
+    }
+  ];
+
+  for (let test of tests) {
+    describe(test.name, function() {
+      let request;
+      before(function() {
+        const app = new Koa();
+        const router = new Router();
+        app.use(async (ctx, next) => {
+          try {
+            await next();
+          } catch (e) {
+            console.log(e);
+            ctx.status = e.status;
+            if (e.errors) {
+              ctx.body = {
+                status: e.status || 500,
+                errors: e.errors
+              };
+            }
+          }
+        });
+        openapi.initialize({
+          apiDoc: generateOpenApiDocWithServers(test.servers),
+          paths: path.resolve(__dirname, 'api-routes'),
+          router
+        });
+        app.use(router.routes());
+        request = supertest(http.createServer(app.callback()));
+      });
+      for (let i of test.expectedPaths) {
+        it(`should have route ${i}`, function(done) {
+          request
+            .get(i)
+            .expect(200)
+            .end(function(error) {
+              done(error);
+            });
+        });
+      }
+    });
+  }
+});
+
+function generateOpenApiDocWithServers(servers) {
+  return {
+    openapi: '3.0.0',
+    info: {
+      title: 'test',
+      version: '1.0'
+    },
+    paths: {},
+    servers
+  };
+}


### PR DESCRIPTION
`express-openapi` and `koa-openapi` now take advantage of new basePaths attribute from `openapi-framework` which is derived from either the basePath attribute in openapi v2 or the servers attribute from openapi v3.  

Closes #274 