### PR TITLE
Fixes support for args.securityHandlers in OpenApi 3

### DIFF
--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -166,12 +166,14 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
   }
 
   public initialize(visitor: OpenAPIFrameworkVisitor) {
+    const securitySchemes = (this.apiDoc as OpenAPIV3.Document).openapi
+      ? (this.apiDoc.components || {}).securitySchemes
+      : this.apiDoc.securityDefinitions;
+
     const apiSecurityMiddleware =
-      this.securityHandlers &&
-      this.apiDoc.security &&
-      this.apiDoc.securityDefinitions
+      this.securityHandlers && this.apiDoc.security && securitySchemes
         ? new OpenAPISecurityHandler({
-            securityDefinitions: this.apiDoc.securityDefinitions,
+            securityDefinitions: securitySchemes,
             securityHandlers: this.securityHandlers,
             operationSecurity: this.apiDoc.security,
             loggingKey: `${this.name}-security`
@@ -426,7 +428,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
               let securityFeature;
               let securityDefinition;
 
-              if (this.securityHandlers && this.apiDoc.securityDefinitions) {
+              if (this.securityHandlers && securitySchemes) {
                 if (operationDoc.security) {
                   securityDefinition = operationDoc.security;
                 } else if (this.pathSecurity.length) {
@@ -440,7 +442,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
               if (securityDefinition) {
                 pathDoc[methodName].security = securityDefinition;
                 securityFeature = new OpenAPISecurityHandler({
-                  securityDefinitions: this.apiDoc.securityDefinitions,
+                  securityDefinitions: securitySchemes,
                   securityHandlers: this.securityHandlers,
                   operationSecurity: securityDefinition,
                   loggingKey: `${this.name}-security`

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-security-and-securityHandlers-and-securityDefinitions-in-openapi-3/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-security-and-securityHandlers-and-securityDefinitions-in-openapi-3/apiDoc.yml
@@ -1,0 +1,11 @@
+openapi: '3.0.2'
+info:
+  title: sample api doc
+  version: '3'
+paths: {}
+security:
+  - basic: []
+components:
+  securitySchemes:
+    basic:
+      type: basic

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-security-and-securityHandlers-and-securityDefinitions-in-openapi-3/paths/foo.js
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-security-and-securityHandlers-and-securityDefinitions-in-openapi-3/paths/foo.js
@@ -1,0 +1,21 @@
+module.exports = {
+  GET
+};
+
+function GET() {
+  return;
+}
+GET.apiDoc = {
+  responses: {
+    '200': {
+      description: 'return foo',
+      content: {
+        'text/plain': {
+          schema: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+};

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-security-and-securityHandlers-and-securityDefinitions-in-openapi-3/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-security-and-securityHandlers-and-securityDefinitions-in-openapi-3/spec.ts
@@ -1,0 +1,55 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      paths: path.resolve(__dirname, 'paths'),
+      securityHandlers: {
+        basic() {
+          return true;
+        }
+      }
+    });
+  });
+
+  it('should work', () => {
+    framework.initialize({
+      visitOperation(ctx) {
+        // throw new Error(JSON.stringify(ctx, null, 4));
+        expect(ctx.features.responseValidator).to.not.be.undefined;
+        expect(ctx.features.requestValidator).to.be.undefined;
+        expect(ctx.features.coercer).to.be.undefined;
+        expect(ctx.features.defaultSetter).to.be.undefined;
+        expect(ctx.features.securityHandler).to.not.be.undefined;
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.paths['/foo']).to.eql({
+          parameters: [],
+          get: {
+            responses: {
+              '200': {
+                description: 'return foo',
+                content: {
+                  'text/plain': {
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
For context, see #305 and #259 

Based on @jwmur's work in #259.

@jsdevel Let me know if you need me to fix anything in this PR or add any tests etc.

Thanks!