### PR TITLE
openapi-response-validator: Deep clone schemas before transforming nullable values.

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -222,7 +222,7 @@ function transformOpenAPIV3Definitions(schema) {
   if (typeof schema !== 'object') {
     return schema;
   }
-  const res = { ...schema };
+  const res = JSON.parse(JSON.stringify(schema));
   recursiveTransformOpenAPIV3Definitions(res);
   return res;
 }


### PR DESCRIPTION
Previously, the response validator would mutate properties in the api doc where nullable: true for openapi v3 docs. For example,  ```{ name: {type: "string", nullable: true}}``` would become ```{ name: {type: ["string", null]}}```, so when the framework tries to validate the doc after populating paths, it would fail validation. Now  that schema is deep copied with lodash.clonedeep as opposed to shallow copied with the spread operator, the api doc doesn't mutate and stays valid after passing through the response validator.