### PR TITLE
openapi-request-validator: Handle missing or invalid 'Content-Type'

### DIFF
--- a/packages/openapi-request-validator/test/data-driven/fail-bad-media-type-for-request-body.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-bad-media-type-for-request-body.js
@@ -1,0 +1,32 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              foo: {
+                type: 'string'
+              }
+            },
+            required: ['foo']
+          }
+        }
+      }
+    }
+  },
+  request: {
+    headers: {
+      'content-type': 'abcdef'
+    }
+  },
+  expectedError: {
+    status: 415,
+    errors: [
+      {
+        message: 'Unsupported Content-Type abcdef'
+      }
+    ]
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/handle-missing-content-type-as-missing-body.js
+++ b/packages/openapi-request-validator/test/data-driven/handle-missing-content-type-as-missing-body.js
@@ -1,0 +1,33 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              foo: {
+                type: 'string'
+              }
+            },
+            required: ['foo']
+          }
+        }
+      }
+    }
+  },
+  request: {
+    headers: {}
+  },
+  expectedError: {
+    status: 400,
+    errors: [
+      {
+        errorCode: 'required.openapi.validation',
+        message: 'media type is not specified',
+        location: 'body'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
`OpenAPIRequestValidator.validate(request)` currently fails with `TypeError` if `Content-Type` header is missing or invalid and `requestBody` is defined in schema.

This PR makes it return `415 Unsupported Media Type` on invalid `Content-Type` and `400 Bad Request` if `Content-Type` is missing but required by `requestBody`.
