### PR TITLE
openapi-types: relax security requirement object types

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -253,10 +253,7 @@ export namespace OpenAPIV3 {
   }
 
   export interface SecurityRequirementObject {
-    apiKey?: string[];
-    http?: string[];
-    oauth2?: string[];
-    openIdConnect?: string[];
+    [name: string]: string[];
   }
 
   export interface ComponentsObject {


### PR DESCRIPTION
Specification allows arbitrary names for security schemes,
but current types restrict it to 4 hard-coded values.

See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object