### PR TITLE
Property items can't be array

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -606,7 +606,7 @@ export interface IJsonSchema {
   minLength?: number;
   pattern?: string;
   additionalItems?: boolean | IJsonSchema;
-  items?: IJsonSchema | IJsonSchema[];
+  items?: IJsonSchema;
   maxItems?: number;
   minItems?: number;
   uniqueItems?: boolean;


### PR DESCRIPTION
> items - Value MUST be an object and not an array. Inline or referenced schema MUST be of a Schema Object and not a standard JSON Schema. items MUST be present if the type is array.

Check openapi 3 spec: https://swagger.io/specification/