### PR TITLE
feat: different approach to handle operations in openapi-framework initialization

### DIFF
--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -197,7 +197,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
 
     let paths = [];
     let routes = [];
-    let routesCheckMap = {};
+    const routesCheckMap = {};
 
     if (this.paths) {
       paths = [].concat(this.paths);
@@ -258,7 +258,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                 const operation = this.operations[operationId];
 
                 acc[METHOD_ALIASES[method]] = (() => {
-                  let innerFunction: any = operation;
+                  const innerFunction: any = operation;
                   innerFunction.apiDoc = methodDoc;
                   return innerFunction;
                 })();

--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -255,12 +255,10 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
               if (operationId && operationId in this.operations) {
                 const operation = this.operations[operationId];
 
-                console.log(operation);
-
                 acc[METHOD_ALIASES[method]] = (() => {
-                  let _f: any = operation;
-                  _f.apiDoc = methodDoc;
-                  return _f;
+                  let innerFunction: any = operation;
+                  innerFunction.apiDoc = methodDoc;
+                  return innerFunction;
                 })();
               } else {
                 this.logger.warn(
@@ -268,7 +266,6 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                 );
               }
 
-              console.log(acc);
               return acc;
             }, {})
         };

--- a/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/apiDoc.yml
@@ -1,0 +1,18 @@
+swagger: '2.0'
+info:
+  title: sample api doc
+  version: '3'
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        default:
+          description: return foo
+          schema: {}
+    post:
+      operationId: postFoo
+      responses:
+        default:
+          description: return foo
+          schema: {}

--- a/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/operations/foo.js
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/operations/foo.js
@@ -1,0 +1,8 @@
+module.exports = {
+  getFoo: function getFoo() {
+    return;
+  },
+  postFoo: function getFoo() {
+    return;
+  }
+};

--- a/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/spec.ts
@@ -1,0 +1,65 @@
+/* tslint:disable:no-unused-expression */
+import {expect} from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      operations: require('./operations/foo')
+    });
+  });
+
+  it('should work', () => {
+    let postFeatures;
+    let getFeatures;
+    framework.initialize({
+      visitOperation(ctx) {
+        if (ctx.methodName === 'get') {
+          getFeatures = ctx.features;
+        } else if (ctx.methodName === 'post') {
+          postFeatures = ctx.features;
+        }
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.paths['/foo']).to.eql({
+          get: {
+            operationId: 'getFoo',
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {}
+              }
+            }
+          },
+          post: {
+            operationId: 'postFoo',
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {}
+              }
+            }
+          },
+          parameters: []
+        });
+      }
+    });
+    expect(getFeatures.responseValidator).to.not.be.undefined;
+    expect(getFeatures.requestValidator).to.be.undefined;
+    expect(getFeatures.coercer).to.be.undefined;
+    expect(getFeatures.defaultSetter).to.be.undefined;
+    expect(getFeatures.securityHandler).to.be.undefined;
+    expect(postFeatures.responseValidator).not.to.be.undefined;
+    expect(postFeatures.requestValidator).to.be.undefined;
+    expect(postFeatures.coercer).to.be.undefined;
+    expect(postFeatures.defaultSetter).to.be.undefined;
+    expect(postFeatures.securityHandler).to.be.undefined;
+  });
+});

--- a/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-multiple-methods/spec.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-unused-expression */
-import {expect} from 'chai';
+import { expect } from 'chai';
 import OpenapiFramework from '../../../';
 const path = require('path');
 


### PR DESCRIPTION
This initially implements a different approach for `args.operations` handling so that it's easier to handle multiple methods per path, which is not fully working as per #352.

Current issue is mainly with tests `operations-dir-with-overlap` and `operations-dir`, which have overlapping/duplicated routes due to `paths` and `operations` being used at the same time. What should be the behavior for those cases?