### PR TITLE
Dependency injection for operations

### DIFF
--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -742,6 +742,33 @@ initialize({
 app.listen(3000);
 ```
 
+Operations also get `args.dependencies` injected as
+`this.dependencies` on the function scope.
+
+```js
+// ./app.js
+import express from 'express';
+import { initialize } from 'express-openapi';
+
+const app = express();
+
+initialize({
+  app,
+  apiDoc: './apiDoc.yml',
+  dependencies: {
+    log: console.log
+  },
+  operations: {
+    getFoo: function(req, res) {
+      this.log('calling request handler');
+      res.send('foo');
+    }
+  }
+});
+
+app.listen(3000);
+```
+
 **Note:** Handlers in args.paths take precedence over handlers in args.operations for
 historical reasons.
 

--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -766,7 +766,7 @@ initialize({
   },
   operations: {
     getFoo: function(req, res) {
-      this.log('calling request handler');
+      this.dependencies.log('calling request handler');
       res.send('foo');
     }
   }
@@ -774,15 +774,6 @@ initialize({
 
 app.listen(3000);
 ```
-
-**Note:** `args.dependencies` is added to the operation's `this`
-context via `operation.bind({dependencies: args.dependencies})`.  This
-requires your operations to be regular [function
-expressions](https://developer.mozilla.org/en-US/docs/web/JavaScript/Refeerence/Operators/function)
-and not [arrow
-functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
-(due to the fact that `this` is lexical to the surrounding scope in an
-arrow function and cannot be bound to anything else). 
 
 #### args.pathSecurity
 

--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -770,8 +770,14 @@ initialize({
 app.listen(3000);
 ```
 
-**Note:** Handlers in args.paths take precedence over handlers in args.operations for
-historical reasons.
+**Note:** `args.dependencies` is added to the operation's `this`
+context via `operation.bind({dependencies: args.dependencies})`.  This
+requires your operations to be regular [function
+expressions](https://developer.mozilla.org/en-US/docs/web/JavaScript/Refeerence/Operators/function)
+and not [arrow
+functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+(due to the fact that `this` is lexical to the surrounding scope in an
+arrow function and cannot be bound to anything else). 
 
 #### args.pathSecurity
 

--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -743,8 +743,13 @@ app.listen(3000);
 ```
 
 Operations also get `args.dependencies` injected as
-`this.dependencies` on the function scope. This requires the operation
-function to be a named, non-anonymous, function.
+`this.dependencies` on the function scope. This requires your
+operations to be regular [function
+expressions](https://developer.mozilla.org/en-US/docs/web/JavaScript/Reference/Operators/function)
+and not [arrow
+functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+(due to the fact that `this` is lexical to the surrounding scope in an
+arrow function and cannot be bound to anything else). x
 
 ```js
 // ./app.js

--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -743,7 +743,8 @@ app.listen(3000);
 ```
 
 Operations also get `args.dependencies` injected as
-`this.dependencies` on the function scope.
+`this.dependencies` on the function scope. This requires the operation
+function to be a named, non-anonymous, function.
 
 ```js
 // ./app.js

--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -912,8 +912,7 @@ function, or an array of business specific middleware + a method handler functio
 defined in the method's `apiDoc` property.  If no `apidoc` property exists on the
 module method, then `express-openapi` will add no additional middleware.
 
-**Note:** Handlers in args.paths take precedence over handlers in args.operations for
-historical reasons.
+**Note:** Handlers in args.operations will override handlers in args.paths
 
 #### args.pathsIgnore
 

--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -262,7 +262,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                   innerFunction.apiDoc = methodDoc;
                   // Operations get dependencies injected in `this`
                   return innerFunction.bind({
-                    dependencies: this.dependencies
+                    dependencies: { ...this.dependencies }
                   });
                 })();
               } else {

--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -260,7 +260,10 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                 acc[METHOD_ALIASES[method]] = (() => {
                   const innerFunction: any = operation;
                   innerFunction.apiDoc = methodDoc;
-                  return innerFunction;
+                  // Operations get dependencies injected in `this`
+                  return innerFunction.bind({
+                    dependencies: this.dependencies
+                  });
                 })();
               } else {
                 this.logger.warn(

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/apiDoc.yml
@@ -1,0 +1,13 @@
+swagger: '2.0'
+info:
+  title: sample api doc
+  version: '3'
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        default:
+          description: return foo
+          schema: {}
+  

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/operations/foo.js
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/operations/foo.js
@@ -1,0 +1,6 @@
+module.exports = function getFoo() {
+  if (this.dependencies.sum(1, 1) !== 2) {
+    throw Error('1 + 1 != 2');
+  }
+  return;
+};

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
@@ -1,0 +1,51 @@
+/* tslint:disable:no-unused-expression */
+import {expect} from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      dependencies: {
+        sum: (a, b) => {
+          return a + b;
+        }
+      },
+      featureType: 'middleware',
+      name: 'some-framework',
+      operations: {
+        getFoo: require('./operations/foo')
+      }
+    });
+  });
+
+  it('should work', () => {
+    framework.initialize({
+      visitOperation(ctx) {
+        expect(ctx.features.responseValidator).to.not.be.undefined;
+        expect(ctx.features.requestValidator).to.be.undefined;
+        expect(ctx.features.coercer).to.be.undefined;
+        expect(ctx.features.defaultSetter).to.be.undefined;
+        expect(ctx.features.securityHandler).to.be.undefined;
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.paths['/foo']).to.eql({
+          parameters: [],
+          get: {
+            operationId: 'getFoo',
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {}
+              }
+            }
+          }
+        });
+      }
+    });
+  });
+});

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-unused-expression */
-import {expect} from 'chai';
+import { expect } from 'chai';
 import OpenapiFramework from '../../../';
 const path = require('path');
 


### PR DESCRIPTION
Inject dependencies on operations by the means of binding the operation handlers so that they get `this.dependencies`