### PR TITLE
fs-routes: add logger(#61)

### DIFF
--- a/packages/fs-routes/index.ts
+++ b/packages/fs-routes/index.ts
@@ -1,5 +1,6 @@
 const glob = require('glob');
 const path = require('path');
+import { dummyLogger, Logger } from 'ts-log';
 const memo = {};
 
 function compare(a: string, b: string) {
@@ -42,9 +43,11 @@ export interface FsRoute {
 
 export default function fsRoutes(
   dir: string,
-  options: FsRoutesOptions = {}
+  options: FsRoutesOptions = {},
+  logger: Logger = dummyLogger
 ): FsRoute[] {
   dir = path.resolve(process.cwd(), dir);
+  logger.debug('fs-routes::reading from', dir);
   options.glob = options.glob || '**/*.js';
   options.indexFileRegExp = options.indexFileRegExp || /(?:index)?\.js$/;
   const cacheKey = dir + options.glob;
@@ -57,6 +60,7 @@ export default function fsRoutes(
         path: path.resolve(dir, file),
         route: '/' + file.replace(options.indexFileRegExp, '')
       }));
+    logger.debug(`fs-routes::${cacheKey}:`, memo[cacheKey]);
   }
 
   return memo[cacheKey];

--- a/packages/fs-routes/package-lock.json
+++ b/packages/fs-routes/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "fs-routes",
   "version": "2.0.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ts-log": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.1.4.tgz",
+      "integrity": "sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ=="
+    }
+  }
 }

--- a/packages/fs-routes/package.json
+++ b/packages/fs-routes/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/kogosoftwarellc/open-api/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Afs-routes"
   },
   "homepage": "https://github.com/kogosoftwarellc/open-api/tree/master/packages/fs-routes#readme",
+  "dependencies": {
+    "ts-log": "*"
+  },
   "peerDependencies": {
     "glob": "*"
   }


### PR DESCRIPTION
i had to add ts-log as a dependency, doesn't work as a peerDependency, because the exported interface changes