### PR TITLE
openapi-request-validator: Allow to use request validation without parameters

### DIFF
--- a/packages/openapi-request-validator/test/data-driven/accept-no-parameters.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-no-parameters.js
@@ -1,0 +1,32 @@
+module.exports = {
+  validateArgs: {
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Test1'
+          }
+        }
+      }
+    },
+    schemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        required: ['foo']
+      }
+    }
+  },
+  request: {
+    body: {
+      foo: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};


### PR DESCRIPTION
The request validation feature now can be used without define parameters, since requestBody is also valid by his own

Closes #381