### PR TITLE
Accept a requestBody with missing readOnly required property in ref (fixes #389)

### DIFF
--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-ref.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-ref.js
@@ -1,0 +1,37 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Test1'
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string',
+            readOnly: true
+          },
+          bar: {
+            type: 'string'
+          }
+        },
+        required: ['foo', 'bar']
+      }
+    }
+  },
+  request: {
+    body: {
+      bar: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};


### PR DESCRIPTION
Fix for when a requestBody is missing a required and readOnly parameter in a referenced schema. Only affects referenced schemas and OpenAPI3.