### PR TITLE
openapi-request-validator: accept reqBody RO nested ref (fixes #394)

### DIFF
--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-allOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-allOf.js
@@ -1,0 +1,79 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/Test1'
+              },
+              {
+                properties: {
+                  qux: {
+                    type: 'string',
+                    readOnly: true
+                  }
+                },
+                required: ['qux']
+              }
+            ]
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test2'
+          },
+          {
+            properties: {
+              bar: {
+                type: 'string'
+              }
+            },
+            required: ['bar']
+          }
+        ]
+      },
+      Test2: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test3'
+          },
+          {
+            properties: {
+              foo: {
+                type: 'string',
+                readOnly: true
+              }
+            },
+            required: ['foo']
+          }
+        ]
+      },
+      Test3: {
+        type: 'object',
+        properties: {
+          baz: {
+            type: 'string',
+            readOnly: true
+          }
+        },
+        required: ['baz']
+      }
+    }
+  },
+  request: {
+    body: {
+      bar: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-anyOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-anyOf.js
@@ -1,0 +1,82 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            anyOf: [
+              {
+                $ref: '#/components/schemas/Test1'
+              },
+              {
+                properties: {
+                  qux: {
+                    type: 'string',
+                    readOnly: true
+                  },
+                  quux: {
+                    type: 'string'
+                  }
+                },
+                required: ['qux', 'quux']
+              }
+            ]
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test2'
+          },
+          {
+            properties: {
+              bar: {
+                type: 'string'
+              }
+            },
+            required: ['bar']
+          }
+        ]
+      },
+      Test2: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test3'
+          },
+          {
+            properties: {
+              foo: {
+                type: 'string',
+                readOnly: true
+              }
+            },
+            required: ['foo']
+          }
+        ]
+      },
+      Test3: {
+        type: 'object',
+        properties: {
+          baz: {
+            type: 'string',
+            readOnly: true
+          }
+        },
+        required: ['baz']
+      }
+    }
+  },
+  request: {
+    body: {
+      quux: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-array.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-array.js
@@ -1,0 +1,43 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              $ref: '#/components/schemas/Test1'
+            }
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            readOnly: true
+          },
+          bar: {
+            type: 'string'
+          }
+        },
+        required: ['foo', 'bar']
+      }
+    }
+  },
+  request: {
+    body: [
+      {
+        bar: 'asdf'
+      }
+    ],
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-nested-refs.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-nested-refs.js
@@ -1,0 +1,66 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Test1'
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test2'
+          },
+          {
+            properties: {
+              bar: {
+                type: 'string'
+              }
+            },
+            required: ['bar']
+          }
+        ]
+      },
+      Test2: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test3'
+          },
+          {
+            properties: {
+              foo: {
+                type: 'string',
+                readOnly: true
+              }
+            },
+            required: ['foo']
+          }
+        ]
+      },
+      Test3: {
+        type: 'object',
+        properties: {
+          baz: {
+            type: 'string',
+            readOnly: true
+          }
+        },
+        required: ['baz']
+      }
+    }
+  },
+  request: {
+    body: {
+      bar: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-oneOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-oneOf.js
@@ -1,0 +1,82 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            oneOf: [
+              {
+                $ref: '#/components/schemas/Test1'
+              },
+              {
+                properties: {
+                  qux: {
+                    type: 'string',
+                    readOnly: true
+                  },
+                  quux: {
+                    type: 'string'
+                  }
+                },
+                required: ['qux', 'quux']
+              }
+            ]
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test2'
+          },
+          {
+            properties: {
+              bar: {
+                type: 'string'
+              }
+            },
+            required: ['bar']
+          }
+        ]
+      },
+      Test2: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test3'
+          },
+          {
+            properties: {
+              foo: {
+                type: 'string',
+                readOnly: true
+              }
+            },
+            required: ['foo']
+          }
+        ]
+      },
+      Test3: {
+        type: 'object',
+        properties: {
+          baz: {
+            type: 'string',
+            readOnly: true
+          }
+        },
+        required: ['baz']
+      }
+    }
+  },
+  request: {
+    body: {
+      quux: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/fail-request-body-when-oneOf-meets-multiple-schemas.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-request-body-when-oneOf-meets-multiple-schemas.js
@@ -1,0 +1,94 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            oneOf: [
+              {
+                $ref: '#/components/schemas/Test1'
+              },
+              {
+                properties: {
+                  qux: {
+                    type: 'string',
+                    readOnly: true
+                  },
+                  quux: {
+                    type: 'string'
+                  }
+                },
+                required: ['qux', 'quux']
+              }
+            ]
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test2'
+          },
+          {
+            properties: {
+              bar: {
+                type: 'string'
+              }
+            },
+            required: ['bar']
+          }
+        ]
+      },
+      Test2: {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Test3'
+          },
+          {
+            properties: {
+              foo: {
+                type: 'string',
+                readOnly: true
+              }
+            },
+            required: ['foo']
+          }
+        ]
+      },
+      Test3: {
+        type: 'object',
+        properties: {
+          baz: {
+            type: 'string',
+            readOnly: true
+          }
+        },
+        required: ['baz']
+      }
+    }
+  },
+  request: {
+    body: {
+      bar: 'asdf',
+      quux: 'asdf'
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  },
+
+  expectedError: {
+    status: 400,
+    errors: [
+      {
+        errorCode: 'oneOf.openapi.validation',
+        message: 'should match exactly one schema in oneOf',
+        location: 'body'
+      }
+    ]
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/fail-requestBody-with-required-readOnly-property-value-false.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-requestBody-with-required-readOnly-property-value-false.js
@@ -1,0 +1,55 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              $ref: '#/components/schemas/Test1'
+            }
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            readOnly: false
+          },
+          bar: {
+            type: 'string'
+          }
+        },
+        required: ['foo', 'bar']
+      }
+    }
+  },
+  request: {
+    body: [
+      {
+        bar: 'asdf'
+      }
+    ],
+    headers: {
+      'content-type': 'application/json'
+    }
+  },
+
+  expectedError: {
+    status: 400,
+    errors: [
+      {
+        path: '[0].foo',
+        errorCode: 'required.openapi.validation',
+        message: "should have required property 'foo'",
+        location: 'body'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Some insight:

- Allows required properties to be missing from requestBody if readOnly
- Works with nested ref
- Works with array where items are ref
- Works with AllOf, AnyOf and OneOf
- Adds tests

I've achieved this within the request-validator package by cloning the schemas, resolving refs and removing all instances of readOnly properties from the required array of their respective schemas.

Edit: Clarity