### PR TITLE
Correct example for validating all responses

### DIFF
--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -414,9 +414,11 @@ function validateAllResponses(req, res, next) {
 initialize({
     app: app,
     paths: path.resolve(__dirname, 'api-paths'),
-    'x-express-openapi-additional-middleware': [validateAllResponses],
-    'x-express-openapi-validation-strict': true,
-    apiDoc: apiDoc
+    apiDoc: {
+        ...apiDoc,
+        'x-express-openapi-additional-middleware': [validateAllResponses],
+        'x-express-openapi-validation-strict': true
+    }
 });
 ```
 


### PR DESCRIPTION
The `x-express-openapi-additional-middleware` setting is on the `apiDoc`.