### PR TITLE
openapi-response-validator: Set "useDefaults: true" on Ajv

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -72,6 +72,7 @@ export default class OpenAPIResponseValidator
       typeof args.errorTransformer === 'function' && args.errorTransformer;
 
     const v = new Ajv({
+      useDefaults: true,
       allErrors: true,
       unknownFormats: 'ignore',
       missingRefs: 'fail',

--- a/packages/openapi-response-validator/test/data-driven/accept-valid-responses-with-defaults.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-valid-responses-with-defaults.js
@@ -1,0 +1,25 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      200: {
+        schema: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+              default: 'asdf'
+            }
+          },
+          required: ['foo']
+        }
+      }
+    },
+
+    definitions: null
+  },
+
+  inputStatusCode: 200,
+  inputResponseBody: {},
+
+  expectedValidationError: void 0
+};


### PR DESCRIPTION
Follow up to #409