### PR TITLE
Fix for #418

### DIFF
--- a/packages/express-openapi/test/sample-projects/file-upload-v3-put/api-doc.js
+++ b/packages/express-openapi/test/sample-projects/file-upload-v3-put/api-doc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  openapi: '3.0.0',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  components: {},
+
+  paths: {},
+
+  tags: [{ description: 'Drafts', name: 'Drafts' }]
+};

--- a/packages/express-openapi/test/sample-projects/file-upload-v3-put/api-routes/fileupload.js
+++ b/packages/express-openapi/test/sample-projects/file-upload-v3-put/api-routes/fileupload.js
@@ -1,0 +1,34 @@
+module.exports = {
+  put: function(req, res, next) {
+    res.status(200).json({});
+  }
+};
+
+module.exports.put.apiDoc = {
+  summary: "PUT file upload.",
+  operationId: 'PutDraftFileUpload',
+
+  tags: ['Drafts'],
+
+  requestBody: {
+    description: 'The binary asset data.',
+    required: true,
+    content: {
+      '*/*': {
+        schema: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  },
+
+  responses: {
+    200: {
+      description: 'OK'
+    },
+    400: {
+      description: 'BAD'
+    }
+  }
+};

--- a/packages/express-openapi/test/sample-projects/file-upload-v3-put/app.js
+++ b/packages/express-openapi/test/sample-projects/file-upload-v3-put/app.js
@@ -1,0 +1,26 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  paths: path.resolve(__dirname, 'api-routes')
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2], 10);
+if (port) {
+  app.listen(port);
+}

--- a/packages/express-openapi/test/sample-projects/file-upload-v3-put/spec.js
+++ b/packages/express-openapi/test/sample-projects/file-upload-v3-put/spec.js
@@ -1,0 +1,63 @@
+var app;
+var expect = require('chai').expect;
+var request = require('supertest');
+
+before(function() {
+  app = require('./app.js');
+});
+
+it('should fail without content-type', function(done) {
+  request(app)
+    .put('/fileupload')
+    .expect(400, {
+      status: 400,
+      errors: [
+        {
+          errorCode: 'required.openapi.validation',
+          message: 'media type is not specified',
+          location: 'body',
+        },
+      ],
+    }, done);
+});
+
+it('should fail with empty content-type', function(done) {
+  request(app)
+    .put('/fileupload')
+    .set('content-type', '')
+    .expect(400, {
+      status: 400,
+      errors: [
+        {
+          errorCode: 'required.openapi.validation',
+          message: 'media type is not specified',
+          location: 'body',
+        },
+      ],
+    }, done);
+});
+
+
+it('should fail without content', function(done) {
+  request(app)
+    .put('/fileupload')
+    .set('content-type', 'text/plain')
+    .expect(400, {
+      status: 400,
+      errors: [
+        {
+          errorCode: 'type.openapi.validation',
+          message: 'should be string',
+          location: 'body',
+        },
+      ],
+    }, done);
+});
+
+it('should upload a file', function(done) {
+  request(app)
+    .put('/fileupload')
+    .set('content-type', 'text/plain')
+    .send('foo')
+    .expect(200, {}, done);
+});


### PR DESCRIPTION
express-openapi for some reason passes on an empty object `{}` as a request body for PUT file uploads, leading to validation errors later on.