### PR TITLE
feat(openapi-request-validator): allow null enums and nullable option

### DIFF
--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-and-type-on-allOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-and-type-on-allOf.js
@@ -1,0 +1,35 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                allOf: [{ $ref: '#/components/schemas/MyType' }],
+                type: 'string',
+                nullable: true
+              }
+            }
+          }
+        }
+      }
+    },
+    schemas: {
+      MyType: {
+        pattern: "^[A-Za-z0-9\\u00C0-÷\\u017F\\s!'¿¡@$€_+=\\-;:/.,?>)(<[]*$"
+      }
+    }
+  },
+  request: {
+    body: {
+      foo: null
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-enum.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-enum.js
@@ -1,0 +1,31 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'string',
+                nullable: true,
+                enum: ['HOME', 'CAR']
+              }
+            }
+          }
+        }
+      }
+    },
+    schemas: null
+  },
+  request: {
+    body: {
+      foo: null
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};


### PR DESCRIPTION
- Allow nullable and null enums on the request validation

Closes #397