### PR TITLE
Correct nullable transform for null examples

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -218,7 +218,7 @@ function recursiveTransformOpenAPIV3Definitions(object) {
   }
 
   Object.keys(object).forEach(attr => {
-    if (typeof object[attr] === 'object') {
+    if (object[attr] !== null && typeof object[attr] === 'object') {
       recursiveTransformOpenAPIV3Definitions(object[attr]);
     }
   });

--- a/packages/openapi-response-validator/test/data-driven/accept-null-examples.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-null-examples.js
@@ -1,0 +1,30 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      '200': {
+        description: 'Ok',
+        schema: {
+          type: 'object',
+          properties: {
+            msisdn: {
+              type: 'string'
+            },
+            countryId: {
+              type: 'string',
+              nullable: true,
+              example: null
+            }
+          },
+          required: ['msisdn']
+        }
+      }
+    },
+
+    definitions: null
+  },
+
+  inputStatusCode: 200,
+  inputResponseBody: { msisdn: '790000000000', countryId: null },
+
+  expectedValidationError: void 0
+};


### PR DESCRIPTION
The `recursiveTransformOpenAPIV3Definitions()` function ironically does
not take into accout that `typeof null == 'object'`. This was causing it
to attempt to transform `null` which results in `TypeError`.

Fixes #413