### PR TITLE
openapi-types: updated typings so that middleware works with typescript

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -29,7 +29,7 @@ export namespace OpenAPIV3 {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
-    'x-express-openapi-additional-middleware'?: Array<(request: express.Request, response: express.Response, next: express.NextFunction) => void | (request: express.Request, response: express.Response, next: express.NextFunction) => Promise<void> >;
+    'x-express-openapi-additional-middleware'?: Array< ((request: any, response: any, next: any) => Promise<void>) | ((request: any, response: any, next: any) => void)>;
     'x-express-openapi-validation-strict'?: boolean;
   }
 

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -30,8 +30,9 @@ export namespace OpenAPIV3 {
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
     'x-express-openapi-additional-middleware'?: Array<
-      ((request: any, response: any, next: any) => Promise<void>)
-      | ((request: any, response: any, next: any) => void)>;
+      | ((request: any, response: any, next: any) => Promise<void>)
+      | ((request: any, response: any, next: any) =>
+         void)>;
     'x-express-openapi-validation-strict'?: boolean;
   }
 

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -32,7 +32,8 @@ export namespace OpenAPIV3 {
     'x-express-openapi-additional-middleware'?: Array<
       | ((request: any, response: any, next: any) => Promise<void>)
       | ((request: any, response: any, next: any) =>
-         void)>;
+ void)
+>;
     'x-express-openapi-validation-strict'?: boolean;
   }
 

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -29,7 +29,8 @@ export namespace OpenAPIV3 {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
-    'x-express-openapi-additional-middleware'?: Array< ((request: any, response: any, next: any) => Promise<void>) | ((request: any, response: any, next: any) => void)>;
+    'x-express-openapi-additional-middleware'?: Array< ((request: any, response: any, next: any) => Promise<void>)
+      | ((request: any, response: any, next: any) => void)>;
     'x-express-openapi-validation-strict'?: boolean;
   }
 

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -29,8 +29,8 @@ export namespace OpenAPIV3 {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
-    'x-express-openapi-additional-middleware'?:
-      Array< ((request: any, response: any, next: any) => Promise<void>)
+    'x-express-openapi-additional-middleware'?: Array<
+      ((request: any, response: any, next: any) => Promise<void>)
       | ((request: any, response: any, next: any) => void)>;
     'x-express-openapi-validation-strict'?: boolean;
   }

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -29,7 +29,8 @@ export namespace OpenAPIV3 {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
-    'x-express-openapi-additional-middleware'?: Array< ((request: any, response: any, next: any) => Promise<void>)
+    'x-express-openapi-additional-middleware'?:
+      Array< ((request: any, response: any, next: any) => Promise<void>)
       | ((request: any, response: any, next: any) => void)>;
     'x-express-openapi-validation-strict'?: boolean;
   }

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -29,6 +29,8 @@ export namespace OpenAPIV3 {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
+    'x-express-openapi-additional-middleware'?: Array<(request: express.Request, response: express.Response, next: express.NextFunction) => void | (request: express.Request, response: express.Response, next: express.NextFunction) => Promise<void> >;
+    'x-express-openapi-validation-strict'?: boolean;
   }
 
   export interface InfoObject {

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -31,9 +31,8 @@ export namespace OpenAPIV3 {
     externalDocs?: ExternalDocumentationObject;
     'x-express-openapi-additional-middleware'?: Array<
       | ((request: any, response: any, next: any) => Promise<void>)
-      | ((request: any, response: any, next: any) =>
- void)
->;
+      | ((request: any, response: any, next: any) => void)
+    >;
     'x-express-openapi-validation-strict'?: boolean;
   }
 


### PR DESCRIPTION
Due to https://github.com/kogosoftwarellc/open-api/issues/126 typescript whines about the apidoc variable when one adds response validation.

*Note: This checklist isn't meant to show up on the actual Pull Request (PR). It is added here to make you aware of items our maintainers will look for when reviewing your PR.  If your PR is missing any of these items it will be rejected!  Please delete this message and the following checklist and replace it with your own message as you see fit.*

- [ ] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [ ] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [ ] My tests pass locally.
- [ ] I have run linting against my code.
