### PR TITLE
openapi-framework: Log an improved warning if the operationId of an operation is not specified (fixes #465)

### DIFF
--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -268,6 +268,12 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                     dependencies: { ...this.dependencies }
                   });
                 })();
+              } else if (operationId === undefined) {
+                this.logger.warn(
+                  `${
+                    this.loggingPrefix
+                  }path ${apiDocPathUrl}, operation ${method} is missing an operationId`
+                );
               } else {
                 this.logger.warn(
                   `${

--- a/packages/openapi-framework/test/sample-projects/missing-operation-id/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/missing-operation-id/apiDoc.yml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  version: "1"
+  title: operationId is missing
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+function ignore(message: any) {}
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+  let warnings: any[] = [];
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      operations: {
+        getFoo: function (req, res) {
+
+        }
+      },
+      logger: {
+        debug: ignore,
+        error: ignore,
+        info: ignore,
+        trace: ignore,
+        warn: (message: any) => {
+          warnings.push(message);
+        }
+      }
+    });
+  });
+
+  it('should throw an error', () => {
+    expect(() => {
+      framework.initialize({});
+    }).to.throw(
+      'Cannot read property \'undefined\' of undefined'
+    );
+    expect(warnings).to.deep.equal([ 'some-framework: path /foo, operation get is missing an operationId' ])
+  });
+});

--- a/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
@@ -2,11 +2,13 @@ import { expect } from 'chai';
 import OpenapiFramework from '../../../';
 const path = require('path');
 
-function ignore(message: any) {}
+function ignore(message: any) {
+  // Logger operation ignored
+}
 
 describe(path.basename(__dirname), () => {
   let framework: OpenapiFramework;
-  let warnings: any[] = [];
+  const warnings: any[] = [];
 
   beforeEach(() => {
     framework = new OpenapiFramework({
@@ -14,8 +16,8 @@ describe(path.basename(__dirname), () => {
       featureType: 'middleware',
       name: 'some-framework',
       operations: {
-        getFoo: function (req, res) {
-
+        getFoo(req, res) {
+          // Operation body
         }
       },
       logger: {
@@ -33,9 +35,9 @@ describe(path.basename(__dirname), () => {
   it('should throw an error', () => {
     expect(() => {
       framework.initialize({});
-    }).to.throw(
-      'Cannot read property \'undefined\' of undefined'
-    );
-    expect(warnings).to.deep.equal([ 'some-framework: path /foo, operation get is missing an operationId' ])
+    }).to.throw("Cannot read property 'undefined' of undefined");
+    expect(warnings).to.deep.equal([
+      'some-framework: path /foo, operation get is missing an operationId'
+    ]);
   });
 });


### PR DESCRIPTION
One new test. I opted to change just the warning and not the exception. If you feel that the exception should be changed as well, then an additional guard clause will need to be inserted.