### PR TITLE
openapi-request-validator: accept reqBody readOnly in nested properties

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -487,7 +487,15 @@ function resolveAndSanitizeRequestBodySchema(
 ) {
   let resolved;
   let copied;
-  if ('$ref' in requestBodySchema) {
+
+  if ('properties' in requestBodySchema) {
+    const schema = requestBodySchema as OpenAPIV3.NonArraySchemaObject;
+    Object.keys(schema.properties).forEach(property => {
+      let prop = schema.properties[property];
+      prop = sanitizeReadonlyPropertiesFromRequired(prop);
+      prop = resolveAndSanitizeRequestBodySchema(prop, v);
+    });
+  } else if ('$ref' in requestBodySchema) {
     resolved = v.getSchema(requestBodySchema.$ref);
     if (resolved && resolved.schema) {
       copied = JSON.parse(JSON.stringify(resolved.schema));

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-deeply-nested.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-deeply-nested.js
@@ -1,0 +1,62 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Test'
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test: {
+        properties: {
+          obj: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'string'
+              },
+              foo: {
+                type: 'string',
+                readOnly: true
+              },
+              baz: {
+                type: 'object',
+                properties: {
+                  bar: {
+                    type: 'string'
+                  },
+                  foo: {
+                    type: 'string',
+                    readOnly: true
+                  }
+                },
+                required: ['bar', 'foo']
+              }
+            },
+            required: ['bar', 'foo']
+          },
+          baz: {
+            type: 'string',
+            readOnly: true
+          }
+        },
+        required: ['obj', 'baz']
+      }
+    }
+  },
+  request: {
+    body: {
+      obj: {
+        bar: 'asdf'
+      }
+    },
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};


### PR DESCRIPTION
Hi,

#400 fixed the nested readOnly behaviour for all schemas with refs. But if you are not using refs for nested properties, it will not allow you to use readOnly properties correctly.

This change will call the sanitize function and itself (recursive) for all properties inside the current schema. The recursive call will ensure that all nested properties are resolved and sanitized, no matter how deep they are nested.

Thanks for maintaining this project! ❤️ 