### PR TITLE
express-openapi: allow to registered errorMiddleware when exposeApiDo…

### DIFF
--- a/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/api-doc.js
+++ b/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/api-doc.js
@@ -1,0 +1,22 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {
+    Foo: {
+      type: 'string'
+    }
+  },
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/api-routes/foo.js
+++ b/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/api-routes/foo.js
@@ -1,0 +1,16 @@
+module.exports = {
+  get: function(req, res, next) {
+    next(new Error('hello from /v3/foo'));
+  }
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  parameters: [],
+  responses: {
+    200: {
+      description: 'testing error handler'
+    }
+  }
+};

--- a/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/app.js
+++ b/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/app.js
@@ -1,0 +1,34 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+app.get('/foo', function(req, res, next) {
+  next(new Error('hello from /foo'));
+});
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  paths: path.resolve(__dirname, 'api-routes'),
+  exposeApiDocs: false,
+  errorMiddleware: function(err, req, res, next) {
+    res.status(200).json(err.message);
+  }
+});
+
+app.use(function(err, req, res, next) {
+  res.status(200).json(err.message);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2], 10);
+if (port) {
+  app.listen(port);
+}

--- a/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/spec.js
+++ b/packages/express-openapi/test/sample-projects/with-errorMiddleware-and-exposeApiDocs-set-to-false/spec.js
@@ -1,0 +1,23 @@
+var app;
+var expect = require('chai').expect;
+var request = require('supertest');
+
+before(function() {
+  app = require('./app.js');
+});
+
+describe('when an error occurs in the basePath', function() {
+  it('should use the API error middleware', function(done) {
+    request(app)
+      .get('/v3/foo')
+      .expect(200, '"hello from /v3/foo"', done);
+  });
+});
+
+describe('when an error occurs outside the basePath', function() {
+  it('should not use the API error middleware', function(done) {
+    request(app)
+      .get('/foo')
+      .expect(200, '"hello from /foo"', done);
+  });
+});


### PR DESCRIPTION
ref: https://github.com/kogosoftwarellc/open-api/issues/435

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [x] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.
