### PR TITLE
openapi-framework: Suppressing unwanted "Ignoring the 2nd definition"…

### DIFF
--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -350,20 +350,23 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
       this.apiDoc.paths[openapiPath] = pathDoc;
       const methodsProcessed = {};
 
-      [
-        ...Object.keys(pathModule).filter(byMethods),
-        ...Object.keys(pathDoc).filter(byMethods)
-      ].forEach(methodAlias => {
+      new Set(
+        Object.keys(pathModule)
+          .concat(Object.keys(pathDoc))
+          .filter(byMethods)
+      ).forEach(methodAlias => {
         const methodName = METHOD_ALIASES[methodAlias];
         if (methodName in methodsProcessed) {
           this.logger.warn(
             `${
               this.loggingPrefix
-            }${openapiPath}.${methodAlias} has already been defined. Ignoring the 2nd definition...`
+            }${openapiPath}.${methodAlias} has already been defined as ${openapiPath}.${
+              methodsProcessed[methodName]
+            }. Ignoring the 2nd definition...`
           );
           return;
         }
-        methodsProcessed[methodName] = true;
+        methodsProcessed[methodName] = methodAlias;
         // operationHandler may be an array or a function.
         const operationHandler =
           pathModule[methodAlias] ||


### PR DESCRIPTION
ref: #368

This change suppress the unwanted _Ignoring the 2nd definition_ warning that is caused by a [duplicate reference of same method alias](https://github.com/kogosoftwarellc/open-api/commit/a19d5e9830698b569bd7f2e35cbdeaf04189c0b2#diff-acfbb4f9a52d04e45d5b249a6853c5ddR319) (one from module path definition and the other from the doc path definition).

The warning still makes sense when multiple aliases of the same method are defined. Example: `del`and `delete`, or `GET` and  `get`. I changed the logging statement to help correlate the duplicated element.

I have tested locally for non regression. No new test added as it only impact the logs. Note it does suppress the warning in test `basic-usage-with-central-apiDoc` (ref: [comment](https://github.com/kogosoftwarellc/open-api/issues/368#issuecomment-477845090))
 
- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests **(see above)**
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.
