### PR TITLE
openapi-response-validator: remove required writeOnly props from response validation

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -216,6 +216,16 @@ function recursiveTransformOpenAPIV3Definitions(object) {
     object.type = [object.type, 'null'];
     delete object.nullable;
   }
+  // Remove writeOnly properties from required array
+  if (object.properties && object.required) {
+    const writeOnlyProps = Object.keys(object.properties).filter(
+      key => object.properties[key].writeOnly
+    );
+    writeOnlyProps.forEach(value => {
+      const index = object.required.indexOf(value);
+      object.required.splice(index, 1);
+    });
+  }
 
   Object.keys(object).forEach(attr => {
     if (object[attr] !== null && typeof object[attr] === 'object') {

--- a/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property-allOf.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property-allOf.js
@@ -1,0 +1,78 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      '2XX': {
+        schema: {
+          allOf: [
+            {
+              $ref: '#/definitions/picture'
+            },
+            {
+              type: 'object',
+              properties: {
+                content: {
+                  type: 'string',
+                  writeOnly: true
+                }
+              },
+              required: ['content']
+            }
+          ]
+        }
+      }
+    },
+
+    definitions: {
+      picture: {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              url: {
+                type: 'string'
+              }
+            },
+            required: ['url']
+          },
+          {
+            $ref: '#/definitions/test1'
+          }
+        ]
+      },
+      test1: {
+        allOf: [
+          {
+            $ref: '#/definitions/test2'
+          },
+          {
+            type: 'object',
+            properties: {
+              mimetype: {
+                type: 'string',
+                writeOnly: true
+              }
+            },
+            required: ['mimetype']
+          }
+        ]
+      },
+      test2: {
+        type: 'object',
+        properties: {
+          size: {
+            type: 'string'
+          }
+        },
+        required: ['size']
+      }
+    }
+  },
+
+  inputStatusCode: 200,
+  inputResponseBody: {
+    url: 'http://example.com/picture.jpg',
+    size: '2MB'
+  },
+
+  expectedValidationError: void 0
+};

--- a/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property-anyOf.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property-anyOf.js
@@ -1,0 +1,68 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      '2XX': {
+        schema: {
+          anyOf: [
+            {
+              $ref: '#/definitions/test1'
+            },
+            {
+              type: 'object',
+              properties: {
+                content: {
+                  type: 'string',
+                  writeOnly: true
+                },
+                url: {
+                  type: 'string'
+                }
+              },
+              required: ['content', 'url']
+            },
+            {
+              $ref: '#/definitions/test2'
+            }
+          ]
+        }
+      }
+    },
+
+    definitions: {
+      test1: {
+        type: 'object',
+        properties: {
+          content2: {
+            type: 'string',
+            writeOnly: true
+          },
+          url2: {
+            type: 'string'
+          }
+        },
+        required: ['content2', 'url2']
+      },
+      test2: {
+        type: 'object',
+        properties: {
+          content3: {
+            type: 'string',
+            writeOnly: true
+          },
+          url3: {
+            type: 'string'
+          }
+        },
+        required: ['content3', 'url3']
+      }
+    }
+  },
+
+  inputStatusCode: 200,
+  inputResponseBody: {
+    url2: 'http://example.com/picture.jpg',
+    url: 'http://example.com/picture.jpg'
+  },
+
+  expectedValidationError: void 0
+};

--- a/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property-oneOf.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property-oneOf.js
@@ -1,0 +1,71 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      '2XX': {
+        schema: {
+          oneOf: [
+            {
+              $ref: '#/definitions/picture'
+            },
+            {
+              type: 'object',
+              properties: {
+                content: {
+                  type: 'string',
+                  writeOnly: true
+                },
+                url: {
+                  type: 'string'
+                }
+              },
+              required: ['content', 'url']
+            }
+          ]
+        }
+      }
+    },
+
+    definitions: {
+      picture: {
+        oneOf: [
+          {
+            $ref: '#/definitions/test1'
+          },
+          {
+            type: 'object',
+            properties: {
+              content2: {
+                type: 'string',
+                writeOnly: true
+              },
+              url2: {
+                type: 'string'
+              }
+            },
+            required: ['content2', 'url2']
+          }
+        ]
+      },
+      test1: {
+        type: 'object',
+        properties: {
+          content3: {
+            type: 'string',
+            writeOnly: true
+          },
+          url3: {
+            type: 'string'
+          }
+        },
+        required: ['content3', 'url3']
+      }
+    }
+  },
+
+  inputStatusCode: 200,
+  inputResponseBody: {
+    url2: 'http://example.com/picture.jpg'
+  },
+
+  expectedValidationError: void 0
+};

--- a/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property.js
+++ b/packages/openapi-response-validator/test/data-driven/accept-responseBody-with-missing-writeonly-required-property.js
@@ -1,0 +1,43 @@
+module.exports = {
+  constructorArgs: {
+    responses: {
+      '2XX': {
+        schema: {
+          type: 'object',
+          properties: {
+            pictures: {
+              type: 'array',
+              items: {
+                $ref: '#/definitions/picture'
+              }
+            }
+          }
+        }
+      }
+    },
+
+    definitions: {
+      picture: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            writeOnly: true
+          },
+          url: {
+            type: 'string',
+            readOnly: true
+          }
+        },
+        required: ['content', 'url']
+      }
+    }
+  },
+
+  inputStatusCode: 200,
+  inputResponseBody: {
+    pictures: [{ url: 'http://example.com/picture.jpg' }]
+  },
+
+  expectedValidationError: void 0
+};


### PR DESCRIPTION
Almost the same as #472 but now for props which are marked as required and `writeOnly`.

As defined [here](https://json-schema.org/latest/json-schema-validation.html#rfc.section.10.3) this allows to defined props which are required in the request, but must not be part of the response.

_Note_: For now there is no validation if the defined props is really not part of the response, it only removes them from the required array (in response validation). The same problem applies in the `request-validator` for `readOnly` props. 
Ajv [knows this keywords](https://github.com/epoberezkin/ajv#annotation-keywords), but does not validate them, do you have an idea how to add a proper validation for this?
