### PR TITLE
openapi-framework: Add support for $ref in requestBody (closes #486)

### DIFF
--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -42,6 +42,7 @@ import {
   injectDependencies,
   METHOD_ALIASES,
   resolveParameterRefs,
+  resolveRequestBodyRefs,
   resolveResponseRefs,
   sortApiDocTags,
   sortOperationDocTags,
@@ -381,8 +382,15 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
             ? operationDoc.consumes
             : operationDoc &&
               operationDoc.requestBody &&
-              operationDoc.requestBody.content
-            ? Object.keys(operationDoc.requestBody.content)
+              (operationDoc.requestBody.content ||
+                operationDoc.requestBody.$ref)
+            ? Object.keys(
+                resolveRequestBodyRefs(
+                  this,
+                  operationDoc.requestBody,
+                  this.apiDoc
+                ).content
+              )
             : Array.isArray(this.apiDoc.consumes)
             ? this.apiDoc.consumes
             : [];
@@ -488,7 +496,11 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                     : undefined,
                   externalSchemas: this.externalSchemas,
                   customFormats: this.customFormats,
-                  requestBody: operationDoc.requestBody as OpenAPIV3.RequestBodyObject
+                  requestBody: resolveRequestBodyRefs(
+                    this,
+                    operationDoc.requestBody,
+                    this.apiDoc
+                  ) as OpenAPIV3.RequestBodyObject
                 });
                 operationContext.features.requestValidator = requestValidator;
                 this.logger.debug(

--- a/packages/openapi-framework/src/util.ts
+++ b/packages/openapi-framework/src/util.ts
@@ -325,6 +325,34 @@ export function resolveResponseRefs(
   }, {});
 }
 
+export function resolveRequestBodyRefs(
+  framework: IOpenAPIFramework,
+  requestBody,
+  apiDoc
+) {
+  if (requestBody && typeof requestBody.$ref === 'string') {
+    const REQUEST_BODY_REF_REGEX = /^#\/components\/requestBodies\/(.+)$/;
+    const match = REQUEST_BODY_REF_REGEX.exec(requestBody.$ref);
+    const apiDocComponents = apiDoc.components;
+    const apiDocReqBodies = apiDocComponents && apiDocComponents.requestBodies;
+    const definition = match && (apiDocReqBodies || {})[match[1]];
+
+    if (!definition) {
+      throw new Error(
+        `${
+          framework.name
+        }: Invalid requestBody $ref or definition not found in apiDoc.components.requestBodies: ${
+          requestBody.$ref
+        }`
+      );
+    }
+
+    return definition;
+  } else {
+    return requestBody;
+  }
+}
+
 export function sortApiDocTags(apiDoc) {
   if (apiDoc && Array.isArray(apiDoc.tags)) {
     apiDoc.tags.sort((a, b) => {

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-missing-ref/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-missing-ref/apiDoc.yml
@@ -1,0 +1,5 @@
+openapi: '3.0.0'
+info:
+  title: sample api doc
+  version: '3'
+paths: {}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-missing-ref/paths/foo.js
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-missing-ref/paths/foo.js
@@ -1,0 +1,23 @@
+module.exports = {
+  PUT
+};
+
+function PUT() {
+  return;
+}
+PUT.apiDoc = {
+  requestBody: {
+    $ref: '#/components/requestBodies/Bar'
+  },
+  responses: {
+    '200': {
+      description: 'return foo',
+      content: {
+        'application/json': {
+          schema: {}
+        }
+      }
+    }
+  },
+  tags: ['testing', 'example']
+};

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-missing-ref/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-missing-ref/spec.ts
@@ -1,0 +1,25 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      paths: path.resolve(__dirname, 'paths')
+    });
+  });
+
+  it('should throw missing $ref error', () => {
+    expect(() => {
+      framework.initialize({});
+    }).to.throw(
+      'some-framework: Invalid requestBody $ref or definition not found in apiDoc.components.requestBodies: #/components/requestBodies/Bar'
+    );
+  });
+});

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-ref/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-ref/apiDoc.yml
@@ -1,0 +1,11 @@
+openapi: '3.0.0'
+info:
+  title: sample api doc
+  version: '3'
+paths: {}
+components:
+  requestBodies:
+    Foo:
+      content:
+        application/json:
+          schema: {}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-ref/paths/foo.js
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-ref/paths/foo.js
@@ -1,0 +1,23 @@
+module.exports = {
+  PUT
+};
+
+function PUT() {
+  return;
+}
+PUT.apiDoc = {
+  requestBody: {
+    $ref: '#/components/requestBodies/Foo'
+  },
+  responses: {
+    '200': {
+      description: 'return foo',
+      content: {
+        'application/json': {
+          schema: {}
+        }
+      }
+    }
+  },
+  tags: ['testing', 'example']
+};

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-ref/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-valid-method-consumes-requestbody-with-ref/spec.ts
@@ -1,0 +1,45 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      paths: path.resolve(__dirname, 'paths')
+    });
+  });
+
+  it('should add consumes to operation context from requestBody', () => {
+    framework.initialize({
+      visitOperation(ctx) {
+        expect(ctx.consumes).to.eql(['application/json']);
+        expect(ctx.operationDoc).to.eql({
+          requestBody: {
+            $ref: '#/components/requestBodies/Foo'
+          },
+          responses: {
+            '200': {
+              description: 'return foo',
+              content: {
+                'application/json': {
+                  schema: {}
+                }
+              }
+            }
+          },
+          tags: ['example', 'testing']
+        });
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.tags).to.eql([{ name: 'example' }, { name: 'testing' }]);
+      }
+    });
+  });
+});

--- a/packages/openapi-framework/test/sample-projects/resolve-requestBody-reference-v3/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/resolve-requestBody-reference-v3/apiDoc.yml
@@ -1,0 +1,22 @@
+openapi: '3.0.0'
+info:
+  title: sample api doc
+  version: '3'
+paths: {}
+components:
+  requestBodies:
+    Foo:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Document"
+  schemas:
+    Document:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+        path:
+          type: string

--- a/packages/openapi-framework/test/sample-projects/resolve-requestBody-reference-v3/paths/foo.js
+++ b/packages/openapi-framework/test/sample-projects/resolve-requestBody-reference-v3/paths/foo.js
@@ -1,0 +1,23 @@
+module.exports = {
+  PUT
+};
+
+function PUT() {
+  return;
+}
+PUT.apiDoc = {
+  requestBody: {
+    $ref: '#/components/requestBodies/Foo'
+  },
+  responses: {
+    '200': {
+      description: 'return foo',
+      content: {
+        'application/json': {
+          schema: {}
+        }
+      }
+    }
+  },
+  tags: ['testing', 'example']
+};

--- a/packages/openapi-framework/test/sample-projects/resolve-requestBody-reference-v3/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/resolve-requestBody-reference-v3/spec.ts
@@ -1,0 +1,43 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      paths: path.resolve(__dirname, 'paths')
+    });
+  });
+
+  it('should succeed validation with reference for requestBody', () => {
+    framework.initialize({
+      visitOperation(ctx) {
+        expect(ctx.features.requestValidator).to.not.be.undefined;
+        const err = ctx.features.requestValidator.validate({
+          body: { title: 'test' },
+          headers: { 'content-type': 'application/json' }
+        });
+        expect(err).to.be.undefined;
+      }
+    });
+  });
+
+  it('should fail validation with reference for requestBody', () => {
+    framework.initialize({
+      visitOperation(ctx) {
+        expect(ctx.features.requestValidator).to.not.be.undefined;
+        const err = ctx.features.requestValidator.validate({
+          body: {},
+          headers: { 'content-type': 'application/json' }
+        });
+        expect(err).not.to.be.undefined;
+      }
+    });
+  });
+});


### PR DESCRIPTION
This resolves any `$ref` in the operation's `requestBody` prior to determining what media types are consumed and before passing the definition to the validator so that `components.requestBodies` can be used in v3 documents when using validation and/or `consumesMiddleware`. Prior to this change `$ref` in `requestBody` would silently be treated incorrectly due to assumptions on it being defined inline.