### PR TITLE
openapi-jsonschema-parameters:  Adds 'examples' (fixes #513)

### DIFF
--- a/packages/openapi-jsonschema-parameters/index.ts
+++ b/packages/openapi-jsonschema-parameters/index.ts
@@ -79,11 +79,18 @@ function copyValidationKeywords(src) {
   return dst;
 }
 
-function handleNullable(params, paramSchema) {
+function handleNullable(params, paramSchema, param) {
   if (params.nullable) {
+    if (param.hasOwnProperty('examples')) {
+      paramSchema.examples = param.examples;
+    }
     return {
       anyOf: [paramSchema, { type: 'null' }]
     };
+  }
+
+  if (param.hasOwnProperty('examples')) {
+    paramSchema.examples = param.examples;
   }
   return paramSchema;
 }
@@ -112,7 +119,8 @@ function getSchema(parameters, type) {
 
       schema.properties[param.name] = handleNullable(
         param.schema || param,
-        paramSchema
+        paramSchema,
+        param
       );
     });
 

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema-openapi3.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema-openapi3.js
@@ -26,6 +26,11 @@ module.exports = {
         uniqueItems: false,
         enum: ['1', '3'],
         multipleOf: 57
+      },
+      examples: {
+        example1: {
+          value: 'asd'
+        }
       }
     }
   ],
@@ -53,7 +58,12 @@ module.exports = {
           minItems: 7,
           uniqueItems: false,
           enum: ['1', '3'],
-          multipleOf: 57
+          multipleOf: 57,
+          examples: {
+            example1: {
+              value: 'asd'
+            }
+          }
         }
       },
       required: ['foo']

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema.js
@@ -24,7 +24,12 @@ module.exports = {
       minItems: 7,
       uniqueItems: false,
       enum: ['1', '3'],
-      multipleOf: 57
+      multipleOf: 57,
+      examples: {
+        example1: {
+          value: 'asd'
+        }
+      }
     }
   ],
 
@@ -51,7 +56,12 @@ module.exports = {
           minItems: 7,
           uniqueItems: false,
           enum: ['1', '3'],
-          multipleOf: 57
+          multipleOf: 57,
+          examples: {
+            example1: {
+              value: 'asd'
+            }
+          }
         }
       },
       required: ['foo']

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-query-param-to-json-schema.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-query-param-to-json-schema.js
@@ -24,7 +24,12 @@ module.exports = {
       minItems: 7,
       uniqueItems: false,
       enum: ['1', '3'],
-      multipleOf: 57
+      multipleOf: 57,
+      examples: {
+        example1: {
+          value: 'asd'
+        }
+      }
     }
   ],
 
@@ -51,7 +56,12 @@ module.exports = {
           minItems: 7,
           uniqueItems: false,
           enum: ['1', '3'],
-          multipleOf: 57
+          multipleOf: 57,
+          examples: {
+            example1: {
+              value: 'asd'
+            }
+          }
         }
       },
       required: ['foo']

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-nullable-complex-query-param-to-json-schema.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-nullable-complex-query-param-to-json-schema.js
@@ -25,7 +25,12 @@ module.exports = {
       minItems: 7,
       uniqueItems: false,
       enum: ['1', '3'],
-      multipleOf: 57
+      multipleOf: 57,
+      examples: {
+        example1: {
+          value: 'asd'
+        }
+      }
     }
   ],
 
@@ -54,7 +59,12 @@ module.exports = {
               minItems: 7,
               uniqueItems: false,
               enum: ['1', '3'],
-              multipleOf: 57
+              multipleOf: 57,
+              examples: {
+                example1: {
+                  value: 'asd'
+                }
+              }
             },
             {
               type: 'null'


### PR DESCRIPTION
npm v, 6.10.2
nodejs v. 12.8.1

- [x] My tests pass locally.
 -> I am not able to run the script on my 'Linux Mint'
  On `> ./bin/test` I get `dev-tools/tsc` is a folder, it needs the `.sh` same with mocha, test, ...
  After that I get 
```
openapi-jsonschema-parameters/test/data-driven.ts:5
import { convertParametersToJSONSchema } from '../';
       ^

SyntaxError: Unexpected token {
    at Module._compile (internal/modules/cjs/loader.js:811:22)

```
- [x] I have run linting against my code.
    -> `npm run lint` works but it looks like there are some errors in master

```
ERROR: packages/openapi-framework/index.ts:110:62 - Replace `⏎············arg.type⏎··········` with `arg.type`
ERROR: packages/openapi-framework/index.ts:122:75 - Replace `⏎············arg.className⏎··········` with `arg.className`
ERROR: packages/openapi-framework/index.ts:131:12 - Replace `⏎··········this.loggingPrefix⏎········` with `this.loggingPrefix`
ERROR: packages/openapi-framework/index.ts:213:18 - Replace `⏎················this.loggingPrefix⏎··············` with `this.loggingPrefix`
ERROR: packages/openapi-framework/index.ts:239:18 - Replace `⏎················this.loggingPrefix⏎··············` with `this.loggingPrefix`
ERROR: packages/openapi-framework/index.ts:274:22 - Replace `⏎····················this.loggingPrefix⏎··················` with `this.loggingPrefix`
ERROR: packages/openapi-framework/index.ts:280:22 - Replace `⏎····················this.loggingPrefix⏎··················` with `this.loggingPrefix`
ERROR: packages/openapi-framework/index.ts:292:53 - Replace `⏎··············route.path⏎············` with `route.path`
ERROR: packages/openapi-framework/index.ts:320:73 - Replace `⏎··········dups[0].path⏎········` with `dups[0].path`
ERROR: packages/openapi-framework/index.ts:362:16 - Replace `⏎··············this.loggingPrefix⏎············}${openapiPath}.${methodAlias}·has·already·been·defined·as·${openapiPath}.${⏎··············methodsProcessed[methodName]⏎············` with `this.loggingPrefix}${openapiPath}.${methodAlias}·has·already·been·defined·as·${openapiPath}.${methodsProcessed[methodName]`
ERROR: packages/openapi-framework/index.ts:610:14 - Replace `⏎············this.loggingPrefix⏎··········` with `this.loggingPrefix`
ERROR: packages/openapi-framework/src/util.ts:102:10 - Replace `⏎········framework.name⏎······` with `framework.name`
ERROR: packages/openapi-framework/src/util.ts:108:10 - Replace `⏎········framework.name⏎······` with `framework.name`
ERROR: packages/openapi-framework/src/util.ts:161:69 - Replace `⏎····framework.featureType⏎··` with `framework.featureType`
ERROR: packages/openapi-framework/src/util.ts:164:64 - Replace `⏎····framework.featureType⏎··` with `framework.featureType`
ERROR: packages/openapi-framework/src/util.ts:185:61 - Replace `⏎··········framework.featureType⏎········` with `framework.featureType`
ERROR: packages/openapi-framework/src/util.ts:274:14 - Replace `⏎············framework.name⏎··········}:·Invalid·parameter·$ref·or·definition·not·found·in·apiDoc.parameters:·${⏎············parameter.$ref⏎··········` with `framework.name}:·Invalid·parameter·$ref·or·definition·not·found·in·apiDoc.parameters:·${parameter.$ref`
ERROR: packages/openapi-framework/src/util.ts:311:14 - Replace `⏎············framework.name⏎··········}:·Invalid·response·$ref·or·definition·not·found·in·apiDoc.responses:·${⏎············response.$ref⏎··········` with `framework.name}:·Invalid·response·$ref·or·definition·not·found·in·apiDoc.responses:·${response.$ref`
ERROR: packages/openapi-framework/src/util.ts:342:12 - Replace `⏎··········framework.name⏎········}:·Invalid·requestBody·$ref·or·definition·not·found·in·apiDoc.components.requestBodies:·${⏎··········requestBody.$ref⏎········` with `framework.name}:·Invalid·requestBody·$ref·or·definition·not·found·in·apiDoc.components.requestBodies:·${requestBody.$ref`
ERROR: packages/openapi-request-coercer/index.ts:195:16 - Replace `⏎··············args.loggingKey⏎············` with `args.loggingKey`
ERROR: packages/openapi-request-validator/index.ts:517:59 - Replace `⏎······(⏎········val⏎······` with `(val`
ERROR: packages/openapi-request-validator/index.ts:521:7 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:522:1 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:523:7 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:524:1 - Replace `········` with `······`
ERROR: packages/openapi-request-validator/index.ts:525:1 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:526:5 - Replace `··}⏎····` with `}`
ERROR: packages/openapi-request-validator/index.ts:529:59 - Replace `⏎······(⏎········val⏎······` with `(val`
ERROR: packages/openapi-request-validator/index.ts:533:1 - Replace `········` with `······`
ERROR: packages/openapi-request-validator/index.ts:534:1 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:535:1 - Replace `········` with `······`
ERROR: packages/openapi-request-validator/index.ts:536:1 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:537:1 - Replace `········` with `······`
ERROR: packages/openapi-request-validator/index.ts:538:1 - Replace `······}⏎····` with `····}`
ERROR: packages/openapi-request-validator/index.ts:541:59 - Replace `⏎······(⏎········val⏎······` with `(val`
ERROR: packages/openapi-request-validator/index.ts:545:1 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:546:7 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:547:1 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:548:7 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:549:1 - Delete `··`
ERROR: packages/openapi-request-validator/index.ts:550:5 - Replace `··}⏎····` with `}`
```


