### PR TITLE
fix(openapi-request-validator): allow charset on request content-type

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -376,7 +376,7 @@ function getSchemaForMediaType(
   let matchPoints = 0;
   for (const mediaTypeKey in content) {
     if (content.hasOwnProperty(mediaTypeKey)) {
-      if (contentType === mediaTypeKey) {
+      if (mediaTypeKey.indexOf(contentType) > -1) {
         return mediaTypeKey;
       } else if (mediaTypeKey === '*/*' && wildcardMatchPoints > matchPoints) {
         match = mediaTypeKey;

--- a/packages/openapi-request-validator/test/data-driven/accept-a-charset-on-content-type.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-a-charset-on-content-type.js
@@ -1,0 +1,32 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json; charset=utf-8': {
+          schema: {
+            $ref: '#/components/schemas/Test1'
+          }
+        }
+      }
+    },
+    schemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string',
+            default: 'foo'
+          }
+        },
+        required: ['foo']
+      }
+    }
+  },
+  request: {
+    body: {},
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+};


### PR DESCRIPTION
![](https://media.giphy.com/media/qIhzviNZZbzTa/giphy.gif)

- Allow charset on content-type schemas for request body

Related #406

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [x] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.
