### PR TITLE
openapi-response-validator: add 'errors' on any error (fixes #512)

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -120,8 +120,15 @@ export default class OpenAPIResponseValidator
     } else if (this.validators.default) {
       validator = this.validators.default;
     } else {
+      const message =
+        'An unknown status code was used and no default was provided.';
       return {
-        message: 'An unknown status code was used and no default was provided.'
+        message,
+        errors: [
+          {
+            message
+          }
+        ]
       };
     }
 

--- a/packages/openapi-response-validator/test/data-driven/fail-with-unkown-status-code.js
+++ b/packages/openapi-response-validator/test/data-driven/fail-with-unkown-status-code.js
@@ -24,6 +24,11 @@ module.exports = {
   inputResponseBody: { foo: 'asdf' },
 
   expectedValidationError: {
-    message: 'An unknown status code was used and no default was provided.'
+    message: 'An unknown status code was used and no default was provided.',
+    errors: [
+      {
+        message: 'An unknown status code was used and no default was provided.'
+      }
+    ]
   }
 };


### PR DESCRIPTION
make sure 'errors' is available on any error

alternative to https://github.com/kogosoftwarellc/open-api/pull/519 
`(openapi-response-validator and openapi-request-validator).validate` result will always contain 'errors[0].message' or undefined

