### PR TITLE
remove extra parens from example code

### DIFF
--- a/packages/openapi-jsonschema-parameters/README.md
+++ b/packages/openapi-jsonschema-parameters/README.md
@@ -14,7 +14,7 @@ some other library.
 See `./test/data-driven` for more examples.
 
 ```javascript
-import { convertParametersToJSONSchema } from 'openapi-jsonschema-parameters');
+import { convertParametersToJSONSchema } from 'openapi-jsonschema-parameters';
 
 const parametersSchemas = convertParametersToJSONSchema([
   {


### PR DESCRIPTION
fixing a little typo