### PR TITLE
openapi-default-setter: Support default values from schema property

### DIFF
--- a/packages/openapi-default-setter/test/data-driven/set-defaults-from-query-and-header-schema.js
+++ b/packages/openapi-default-setter/test/data-driven/set-defaults-from-query-and-header-schema.js
@@ -1,0 +1,39 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        in: 'query',
+        name: 'foo',
+        schema: {
+          type: 'string',
+          default: 'asdf'
+        }
+      },
+
+      {
+        in: 'header',
+        name: 'X-foo',
+        schema: {
+          type: 'number',
+          default: 5.345
+        }
+      }
+    ]
+  },
+
+  request: {
+    path: '/',
+    headers: {},
+    query: {}
+  },
+
+  headers: {
+    'x-foo': 5.345
+  },
+
+  params: null,
+
+  query: {
+    foo: 'asdf'
+  }
+};


### PR DESCRIPTION
As described in the spec: https://swagger.io/docs/specification/describing-parameters/#query-parameters, parameter types are described using the `schema` property. The `default` property is defined under `parameter.schema.default`:

```
in: 'query',
name: 'someQuery',
schema: {
  type: 'string',
  default: 'someValue'
}
```

This PR implements support for this. But also keeps the support for reading the default value from the root level of the parameter object.