### PR TITLE
express-openapi: Fixes Typescript example to pick up `.ts` files

### DIFF
--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -1126,12 +1126,14 @@ app.use(bodyParser.json());
 initialize({
     apiDoc: './api-doc.js',
     app,
-    paths: './built/api-paths'
+    paths: './built/api-paths',
+    routesGlob: '**/*.{ts,js}',
+    routesIndexFileRegExp: /(?:index)?\.[tj]s$/
 });
 
-app.use(<express.ErrorRequestHandler>(err, req, res, next) => {
+app.use(((err, req, res, next) => {
     res.status(err.status).json(err);
-});
+}) as express.ErrorRequestHandler);
 
 app.listen(3000);
 ```


### PR DESCRIPTION
Only a `readme` update, no code change.

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`)
- [ ] ~I have added tests.~ 
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses
- [ ] ~My tests pass locally.~
- [ ] ~I have run linting against my code.~
