### PR TITLE
openapi-request-coercer: do not throw on untyped array items

### DIFF
--- a/packages/openapi-request-coercer/package-lock.json
+++ b/packages/openapi-request-coercer/package-lock.json
@@ -8,6 +8,11 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
       "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
+    },
+    "ts-log": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.1.4.tgz",
+      "integrity": "sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ=="
     }
   }
 }

--- a/packages/openapi-request-coercer/package.json
+++ b/packages/openapi-request-coercer/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/kogosoftwarellc/open-api/tree/master/packages/openapi-request-coercer#readme",
   "dependencies": {
-    "openapi-types": "1.3.5"
+    "openapi-types": "1.3.5",
+    "ts-log": "^2.1.4"
   }
 }

--- a/packages/openapi-request-coercer/test/data-driven.ts
+++ b/packages/openapi-request-coercer/test/data-driven.ts
@@ -2,7 +2,42 @@ const expect = require('chai').expect;
 const glob = require('glob');
 const path = require('path');
 const baseDir = path.resolve(__dirname, 'data-driven');
+import { Logger } from 'ts-log';
 import Sut from '../';
+
+interface LogEntry {
+  type: string;
+  message: any | undefined;
+  optionalParams: any[];
+}
+
+class FakeLogger implements Logger {
+  public readonly logEntries: LogEntry[] = [];
+
+  public trace(message?: any, ...optionalParams: any[]): void {
+    this.logEntries.push(this.build('TRACE', message, optionalParams));
+  }
+
+  public debug(message?: any, ...optionalParams: any[]): void {
+    this.logEntries.push(this.build('DEBUG', message, optionalParams));
+  }
+
+  public info(message?: any, ...optionalParams: any[]): void {
+    this.logEntries.push(this.build('INFO', message, optionalParams));
+  }
+
+  public warn(message?: any, ...optionalParams: any[]): void {
+    this.logEntries.push(this.build('WARN', message, optionalParams));
+  }
+
+  public error(message?: any, ...optionalParams: any[]): void {
+    this.logEntries.push(this.build('ERROR', message, optionalParams));
+  }
+
+  private build(type: string, message: any | undefined, optionalParams: any[]) {
+    return { type, message, optionalParams };
+  }
+}
 
 describe(require('../package.json').name, () => {
   glob.sync('*.js', { cwd: baseDir }).forEach(fixture => {
@@ -10,6 +45,11 @@ describe(require('../package.json').name, () => {
     fixture = require(path.resolve(baseDir, fixture));
 
     it(`should ${testName}`, () => {
+      const fakeLogger = new FakeLogger();
+      if (fixture.args) {
+        fixture.args.logger = fakeLogger;
+      }
+
       if (fixture.constructorError) {
         expect(() => {
           /* tslint:disable-next-line:no-unused-expression */
@@ -36,6 +76,12 @@ describe(require('../package.json').name, () => {
 
       if (fixture.body) {
         expect(request.body).to.eql(fixture.body);
+      }
+
+      if (fixture.logs) {
+        expect(fakeLogger.logEntries).to.eql(fixture.logs);
+      } else {
+        expect(fakeLogger.logEntries).to.eql([]);
       }
     });
   });

--- a/packages/openapi-request-coercer/test/data-driven/ignore-unkown-types-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/ignore-unkown-types-openapi3.js
@@ -1,4 +1,21 @@
 module.exports = {
+  logs: [
+    {
+      type: 'WARN',
+      message: '',
+      optionalParams: [
+        "No proper coercion strategy has been found for type 'asdfasdf'. A default 'identity' strategy has been set."
+      ]
+    },
+    {
+      type: 'WARN',
+      message: '',
+      optionalParams: [
+        "No proper coercion strategy has been found for type 'dddd'. A default 'identity' strategy has been set."
+      ]
+    }
+  ],
+
   args: {
     parameters: [
       {

--- a/packages/openapi-request-coercer/test/data-driven/ignore-unkown-types.js
+++ b/packages/openapi-request-coercer/test/data-driven/ignore-unkown-types.js
@@ -1,4 +1,21 @@
 module.exports = {
+  logs: [
+    {
+      type: 'WARN',
+      message: '',
+      optionalParams: [
+        "No proper coercion strategy has been found for type 'asdfasdf'. A default 'identity' strategy has been set."
+      ]
+    },
+    {
+      type: 'WARN',
+      message: '',
+      optionalParams: [
+        "No proper coercion strategy has been found for type 'dddd'. A default 'identity' strategy has been set."
+      ]
+    }
+  ],
+
   args: {
     parameters: [
       {

--- a/packages/openapi-request-coercer/test/data-driven/not-throw-on-untyped-array-params-in-request.js
+++ b/packages/openapi-request-coercer/test/data-driven/not-throw-on-untyped-array-params-in-request.js
@@ -1,0 +1,42 @@
+module.exports = {
+  logs: [
+    {
+      type: 'WARN',
+      message: '',
+      optionalParams: [
+        "No type has been defined. A default 'identity' strategy has been set."
+      ]
+    }
+  ],
+
+  args: {
+    enableObjectCoercion: true,
+    parameters: [
+      {
+        in: 'query',
+        type: 'array',
+        name: 'multi-valued',
+        items: {
+          // Missing type member here...
+          // although this is recommended by the Swagger 2.0 spec
+          // (cf. https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#itemsObject)
+          // this is not enforced by the schema
+          // (cf. https://github.com/OAI/OpenAPI-Specification/blob/7ce374d67e46e2fdf0da49fc6e29f6854985627e/schemas/v2.0/schema.json#L1108-L1176)
+          enum: ['one', 'two']
+        },
+        collectionFormat: 'multi',
+        required: false
+      }
+    ]
+  },
+
+  request: {
+    query: {
+      'multi-valued': 'one'
+    }
+  },
+
+  query: {
+    'multi-valued': ['one']
+  }
+};


### PR DESCRIPTION
Although defining the type of array items is required by the Swagger 2.0 spec, this is sadly not enforced by the schema. This change prevents the library from throwing in such case, by defaulting to an "identity" coercer.

References:
- https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#itemsObject
- https://github.com/OAI/OpenAPI-Specification/blob/7ce374d67e46e2fdf0da49fc6e29f6854985627e/schemas/v2.0/schema.json#L1108-L1176

