### PR TITLE
openapi-request-coercer: drop unused member

### DIFF
--- a/packages/openapi-request-coercer/index.ts
+++ b/packages/openapi-request-coercer/index.ts
@@ -16,7 +16,6 @@ export default class OpenAPIRequestCoercer implements IOpenAPIRequestCoercer {
   private coerceParams;
   private coerceQuery;
   private coerceFormData;
-  private enableObjectCoercion;
 
   constructor(args: OpenAPIRequestCoercerArgs) {
     const loggingKey = args && args.loggingKey ? `${args.loggingKey}: ` : '';


### PR DESCRIPTION
This member is never set nor used.