### PR TITLE
openapi-request-coercer: fix handling of OAS 3 explode

### DIFF
--- a/packages/openapi-request-coercer/index.ts
+++ b/packages/openapi-request-coercer/index.ts
@@ -220,7 +220,7 @@ function buildCoercer(args) {
           // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#style-values
           if (param.style) {
             if (param.style === 'form' && param.in === 'query') {
-              collectionFormat = param.explodes ? 'multi' : 'csv';
+              collectionFormat = param.explode ? 'multi' : 'csv';
             } else if (
               param.style === 'simple' &&
               (param.in === 'path' || param.in === 'header')

--- a/packages/openapi-request-coercer/test/data-driven/coerce-array-with-style-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-array-with-style-openapi3.js
@@ -23,7 +23,7 @@ module.exports = {
           }
         },
         style: 'form',
-        explodes: false
+        explode: false
       },
 
       {
@@ -36,7 +36,7 @@ module.exports = {
           }
         },
         style: 'form',
-        explodes: true
+        explode: true
       },
 
       {


### PR DESCRIPTION
While working on #569, I stumbled on this which I believe is a typo (as the **[spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md)** never references it in the plural form).