### PR TITLE
[WIP] openapi-request-coercer: accept custom coercion strategy

### DIFF
--- a/packages/openapi-request-coercer/README.md
+++ b/packages/openapi-request-coercer/README.md
@@ -44,7 +44,7 @@ By default a boolean parameter is coerced to:
 * _false_ if the input value is "false"
 * _true_ for any other input value
 
-This behaviour is makes sense if you do not wish to validate the input fields.
+This behaviour makes sense if you do not wish to validate the input fields.
 
 If the opposite is the case, the behaviour can be changed by setting the "x-openapi-coercion-strict" to _true_ on the parameter in question as illustrated below.
 
@@ -68,6 +68,43 @@ Doing so will result in the boolean parameter being coerced to:
 * _true_ if the input value is "true" (in any casing)
 * _null_ for any other input value
 
+## Implementing your own custom coercion strategy
+
+Would `x-openapi-coercion-strict` not be strict enough to your test, or would you completely want to customize the coercion behavior you can completely define how simpler types (`boolean`, `integer` and `number`) are dealt with.
+
+In order to do so, define a custom coercion strategy through the optional `coercionStrategy` argument.
+
+For instance, below a sample of a strategy that will:
+ - only coerce stringified boolean values when they are expressed in lowercase in a case sentive way
+ - coerce integers when they are even, otherwise return null
+ - as numbers aren't overridden, the default strategy will be leveraged
+
+```javascript
+import OpenapiRequestCoercer from 'openapi-request-coercer';
+const coercionStrategy = {
+  boolean = (input) => {    
+    if (typeof input === 'boolean') {
+      return input;
+    }
+    if (input === 'false') {
+      return false;
+    }
+    else if (input === 'true') {
+      return true;
+    }
+    return input;
+  };
+  number = (input) => {
+    var result = Number(input);
+    return isNaN(result) || (result%2) === 1 ? null : result;
+  }
+};
+const parameters = { /* ... */ }
+
+const sut = new OpenapiRequestCoercer({ parameters, coercionStrategy });
+const result = sut.coerce(request);
+```
+
 ## API
 
 ### coerce(args)
@@ -79,6 +116,9 @@ Defaults to `''`.
 
 #### args.parameters
 An array of openapi parameters.
+
+#### args.coercionStrategy
+An object exposing the optional `boolean`, `integer`, `number` properties. Each of them, when defined is expected to accept a function accepting a parameter and returning a result.
 
 ## LICENSE
 ``````

--- a/packages/openapi-request-coercer/test/custom-strategy-coercion.ts
+++ b/packages/openapi-request-coercer/test/custom-strategy-coercion.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import Sut, { CoercionStrategy } from '../';
+
+describe('custom coercion strategy', () => {
+  describe('when defined', () => {
+    for (const strictStrategy of [true, false]) {
+      for (const where of [
+        ['query', 'query'],
+        ['path', 'params'],
+        ['header', 'headers']
+      ]) {
+        it(`should override ${
+          strictStrategy ? 'strict' : 'default'
+        } coercion strategy for ${where[0]}`, () => {
+          const parameters = [
+            {
+              in: where[0],
+              name: 'number1',
+              type: 'number',
+              'x-openapi-coercion-strict': strictStrategy
+            },
+
+            {
+              in: where[0],
+              name: 'integer1',
+              type: 'integer',
+              'x-openapi-coercion-strict': strictStrategy
+            },
+
+            {
+              in: where[0],
+              name: 'boolean1',
+              type: 'boolean',
+              'x-openapi-coercion-strict': strictStrategy
+            }
+          ];
+
+          const request = {};
+          request[where[1]] = {
+            number1: '05.32',
+            integer1: '07.00',
+            boolean1: 'FalSe'
+          };
+
+          const seen: string[] = [];
+
+          const dummyStrategy = (type: string, input: any) => {
+            const output = `${type}(${input})`;
+            seen.push(output);
+            return output;
+          };
+
+          const coercionStrategy: CoercionStrategy = {
+            boolean: input => dummyStrategy('boolean', input),
+            number: input => dummyStrategy('number', input),
+            integer: input => dummyStrategy('integer', input)
+          };
+
+          const sut = new Sut({ parameters, coercionStrategy });
+          sut.coerce(request);
+
+          expect(request[where[1]].number1).to.eql('number(05.32)');
+          expect(request[where[1]].integer1).to.eql('integer(07.00)');
+          expect(request[where[1]].boolean1).to.eql('boolean(FalSe)');
+
+          expect(seen).to.have.lengthOf(3);
+          expect(seen).to.include('number(05.32)');
+          expect(seen).to.include('integer(07.00)');
+          expect(seen).to.include('boolean(FalSe)');
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fix #567 

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [x] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.

TBD:
 - [x] Update doco
 - [ ] Add tests covering arrays and objects