### PR TITLE
express-openapi: Added missing RegExp escape character in pathSecurity documentation

### DIFF
--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -795,8 +795,8 @@ initialize({
   /*...*/
   pathSecurity: [
     // here /some/{pathId} will get theirSecurity.
-    [/^\/some/\{pathId\}/, [{mySecurity:[]}]],
-    [/^\/some/\{pathId\}/, [{theirSecurity:[]}]]
+    [/^\/some\/\{pathId\}/, [{mySecurity:[]}]],
+    [/^\/some\/\{pathId\}/, [{theirSecurity:[]}]]
   ]
   /*...*/
 });


### PR DESCRIPTION
The forward slash "/" has to be escaped here.