### PR TITLE
openapi-request-validatior: readOnly properties should be rejected

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -100,6 +100,28 @@ export default class OpenAPIRequestValidator
       logger: false
     });
 
+    v.removeKeyword('readOnly');
+    v.addKeyword('readOnly', {
+      modifying: true,
+      compile: sch => {
+        if (sch) {
+          return function validate(data, path, obj, propName) {
+            const isValid = !(sch === true && data != null);
+            (validate as any).errors = [
+              {
+                keyword: 'readOnly',
+                dataPath: path,
+                message: 'is read-only',
+                params: { readOnly: propName }
+              }
+            ];
+            return isValid;
+          };
+        }
+        return () => true;
+      }
+    });
+
     if (args.requestBody) {
       isBodyRequired = args.requestBody.required || false;
     }

--- a/packages/openapi-request-validator/test/data-driven/fail-requestBody-with-present-readOnly-property.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-requestBody-with-present-readOnly-property.js
@@ -1,0 +1,56 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              $ref: '#/components/schemas/Test1'
+            }
+          }
+        }
+      }
+    },
+    componentSchemas: {
+      Test1: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            readOnly: true
+          },
+          bar: {
+            type: 'string'
+          }
+        },
+        required: ['foo', 'bar']
+      }
+    }
+  },
+  request: {
+    body: [
+      {
+        bar: 'asdf',
+        foo: 'should-not-be-here'
+      }
+    ],
+    headers: {
+      'content-type': 'application/json'
+    }
+  },
+
+  expectedError: {
+    status: 400,
+    errors: [
+      {
+        path: '[0].foo',
+        errorCode: 'readOnly.openapi.requestValidation',
+        message: 'is read-only',
+        location: 'body'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
ReadOnly properties should be present only in response. The request should reject them as those properties should not be modified.

JSON Schema Draft-07 brings new properties “readOnly”. That property allow to use conditional validation of object fields depending on context. That way the same schema definition could be re-use as part of post method where should be missing and get method where field is provided by server site. Here in openapi-request-validatior the context is always write, as we write data to server and all read only fields should be rejected.
