### PR TITLE
openapi-jsonschema-parameters: remove whitelisting of OpenAPI 3 schema validation keywords

### DIFF
--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema-openapi3.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema-openapi3.js
@@ -14,7 +14,7 @@ module.exports = {
         title: 'fffasdf',
         maximum: 0,
         additionalItems: true,
-        items: [],
+        items: [{ nullable: true }],
         exclusiveMaximum: true,
         minimum: 5,
         exclusiveMinimum: false,
@@ -25,7 +25,14 @@ module.exports = {
         minItems: 7,
         uniqueItems: false,
         enum: ['1', '3'],
-        multipleOf: 57
+        multipleOf: 57,
+        properties: {
+          something: { nullable: true }
+        },
+        oneOf: [{ nullable: true }],
+        allOf: [{ nullable: true }],
+        anyOf: [{ nullable: true }],
+        not: { nullable: true }
       },
       examples: {
         example1: {
@@ -49,7 +56,7 @@ module.exports = {
           minimum: 5,
           exclusiveMinimum: false,
           format: 'asdf',
-          items: [],
+          items: [{ anyOf: [{}, { type: 'null' }] }],
           maxLength: 5,
           minLength: 6,
           pattern: '^asdf$',
@@ -59,6 +66,13 @@ module.exports = {
           uniqueItems: false,
           enum: ['1', '3'],
           multipleOf: 57,
+          properties: {
+            something: { anyOf: [{}, { type: 'null' }] }
+          },
+          oneOf: [{ anyOf: [{}, { type: 'null' }] }],
+          allOf: [{ anyOf: [{}, { type: 'null' }] }],
+          anyOf: [{ anyOf: [{}, { type: 'null' }] }],
+          not: { anyOf: [{}, { type: 'null' }] },
           examples: {
             example1: {
               value: 'asd'


### PR DESCRIPTION
- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [x] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.
