### PR TITLE
openapi-types: Add type constraint on SecuritySchemeOauth2Base (fixes #623)

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -379,6 +379,7 @@ export namespace OpenAPIV2 {
   }
 
   interface SecuritySchemeOauth2Base extends SecuritySchemeObjectBase {
+    type: 'oauth2';
     flow: 'implicit' | 'password' | 'application' | 'accessCode';
     scopes: ScopesObject;
   }


### PR DESCRIPTION
- [X] I only have 1 commit.
- [X] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [X] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [X] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [ ] My tests pass locally.
- [ ] I have run linting against my code.

I hope you'll be happy with the lack of tests, as there don't appear to be tests in the openapi-types package!