### PR TITLE
open-api-types: fix x-express-openapi-additional-middleware typings

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -29,6 +29,11 @@ export namespace OpenAPIV3 {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
+    'x-express-openapi-additional-middleware'?: Array<
+      | ((request: any, response: any, next: any) => Promise<void>)
+      | ((request: any, response: any, next: any) => void)
+    >;
+    'x-express-openapi-validation-strict'?: boolean;
   }
 
   export interface InfoObject {
@@ -345,6 +350,11 @@ export namespace OpenAPIV2 {
     securityDefinitions?: SecurityDefinitionsObject;
     swagger: string;
     tags?: TagObject[];
+    'x-express-openapi-additional-middleware'?: Array<
+      | ((request: any, response: any, next: any) => Promise<void>)
+      | ((request: any, response: any, next: any) => void)
+    >;
+    'x-express-openapi-validation-strict'?: boolean;
   }
 
   export interface TagObject {


### PR DESCRIPTION
We have been happily using your open-api packages with great success on our js projects, thanks so much!  However, now that we are moving some things over to typescript we are hitting an issue that I've only been able to find documented in #126

This PR reintroduces those changes from #126 in a format that adheres to the PR guidelines.

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [ ] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.
