### PR TITLE
openapi-types: default response is optional

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -482,7 +482,7 @@ export namespace OpenAPIV2 {
 
   export interface ResponsesObject {
     [index: string]: Response | any;
-    default: Response;
+    default?: Response;
   }
 
   export type Parameters = Array<ReferenceObject | Parameter>;


### PR DESCRIPTION
`OpenAPIV2.ResponseObject` should not require the `default` property.

See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responses-object where `default` is not marked as required.
