### PR TITLE
openapi-jsonschema-parameters: Convert `examples` to an array (fixes #635)

### DIFF
--- a/packages/openapi-jsonschema-parameters/index.ts
+++ b/packages/openapi-jsonschema-parameters/index.ts
@@ -163,14 +163,18 @@ function getSchema(parameters, type) {
     schema = { properties: {} };
 
     params.forEach(param => {
+      let paramSchema;
       if ('schema' in param) {
-        const paramSchema = handleNullableSchema(param.schema);
-        if ('examples' in param && !('examples' in paramSchema)) {
-          paramSchema.examples = param.examples;
+        paramSchema = handleNullableSchema(param.schema);
+        if ('examples' in param) {
+          paramSchema.examples = getExamples(param.examples);
         }
         schema.properties[param.name] = paramSchema;
       } else {
-        const paramSchema = copyValidationKeywords(param);
+        paramSchema = copyValidationKeywords(param);
+        if ('examples' in paramSchema) {
+          paramSchema.examples = getExamples(paramSchema.examples);
+        }
         schema.properties[param.name] = param.nullable
           ? handleNullable(paramSchema)
           : paramSchema;
@@ -185,6 +189,10 @@ function getSchema(parameters, type) {
 
 function getRequiredParams(parameters) {
   return parameters.filter(byRequired).map(toName);
+}
+
+function getExamples(exampleSchema) {
+  return Object.keys(exampleSchema).map((k) => exampleSchema[k].value);
 }
 
 function byIn(str) {

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema-openapi3.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema-openapi3.js
@@ -73,11 +73,7 @@ module.exports = {
           allOf: [{ anyOf: [{}, { type: 'null' }] }],
           anyOf: [{ anyOf: [{}, { type: 'null' }] }],
           not: { anyOf: [{}, { type: 'null' }] },
-          examples: {
-            example1: {
-              value: 'asd'
-            }
-          }
+          examples: ['asd'],
         }
       },
       required: ['foo']

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-path-parameter-to-json-schema.js
@@ -57,11 +57,7 @@ module.exports = {
           uniqueItems: false,
           enum: ['1', '3'],
           multipleOf: 57,
-          examples: {
-            example1: {
-              value: 'asd'
-            }
-          }
+          examples: ['asd']
         }
       },
       required: ['foo']

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-query-param-to-json-schema.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-complex-query-param-to-json-schema.js
@@ -57,11 +57,7 @@ module.exports = {
           uniqueItems: false,
           enum: ['1', '3'],
           multipleOf: 57,
-          examples: {
-            example1: {
-              value: 'asd'
-            }
-          }
+          examples: ['asd'],
         }
       },
       required: ['foo']

--- a/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-nullable-complex-query-param-to-json-schema.js
+++ b/packages/openapi-jsonschema-parameters/test/data-driven/convert-a-single-nullable-complex-query-param-to-json-schema.js
@@ -60,11 +60,7 @@ module.exports = {
               uniqueItems: false,
               enum: ['1', '3'],
               multipleOf: 57,
-              examples: {
-                example1: {
-                  value: 'asd'
-                }
-              }
+              examples: ['asd'],
             },
             {
               type: 'null'


### PR DESCRIPTION
In json schema, the field `examples` is an array, but in openapi, that field is an object. To correctly support `examples`, convert `examples` to an array.