### PR TITLE
openapi-request-coercer: Fix function on Object.prototype being used as coercer

### DIFF
--- a/packages/openapi-request-coercer/index.ts
+++ b/packages/openapi-request-coercer/index.ts
@@ -301,7 +301,7 @@ function buildCoercer(args) {
 
     coercion = obj => {
       for (const paramName in obj) {
-        if (paramName in coercers) {
+        if (coercers.hasOwnProperty(paramName)) {
           obj[paramName] = coercers[paramName](obj[paramName]);
         }
       }

--- a/packages/openapi-request-coercer/test/data-driven/not-use-Object-prototype-entries-as-coercers.js
+++ b/packages/openapi-request-coercer/test/data-driven/not-use-Object-prototype-entries-as-coercers.js
@@ -1,0 +1,22 @@
+const customToString = () => "Hello world"
+
+module.exports = {
+  args: {
+    // We're not coercing any params, but there has to be at least one present for the functionality to kick in
+    parameters: [{
+      in: 'path',
+      name: 'path1',
+      type: 'boolean'
+    }]
+  },
+
+  request: {
+    body: {
+      toString: customToString
+    }
+  },
+
+  body: {
+    toString: customToString
+  }
+};


### PR DESCRIPTION
The coercion function iterates all enumerable properties on the request body and looks for a coercer function inside of the `coercers` object. However, because it checks the `coecers` object for the `paramName` using `in` it will also find entries on the Object prototype and treat them as coercer functions. The effect of this ranges from converting the `toString` function to a string of `[object Object]` to throwing a `TypeError` if a property is named `__defineSetter__`.

The way we discovered the issue was passing a Buffer as the request body (the result of running bodyParser.raw) and then attempting to convert it to base64.