### PR TITLE
openapi-types: Remove null type and make type property optional

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -129,7 +129,6 @@ export namespace OpenAPIV3 {
     content?: { [media: string]: MediaTypeObject };
   }
   export type NonArraySchemaObjectType =
-    | 'null'
     | 'boolean'
     | 'object'
     | 'number'
@@ -144,7 +143,7 @@ export namespace OpenAPIV3 {
   }
 
   interface NonArraySchemaObject extends BaseSchemaObject {
-    type: NonArraySchemaObjectType;
+    type?: NonArraySchemaObjectType;
   }
 
   interface BaseSchemaObject {


### PR DESCRIPTION
OpenAPI Sepcification states that there is no `null` type. Also, to indicate a data model can be of any type, the `type` property can be omitted. I have removed `null` from the union type `NonArraySchemaObjectType` and changed `type: string` => `type?: string` in `NonArraySchemaObject`.

See https://swagger.io/docs/specification/data-models/data-types/

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [ ] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [ ] My tests pass locally.
- [ ] I have run linting against my code.
