### PR TITLE
koa-openapi: Name created routes for later use

### DIFF
--- a/packages/koa-openapi/index.ts
+++ b/packages/koa-openapi/index.ts
@@ -176,7 +176,9 @@ export function initialize(args: KoaOpenAPIInitializeArgs): OpenAPIFramework {
             .split('/')
             .map(toPathParams)
             .join('/');
-        router[methodName](koaPath, async (ctx, next) => {
+
+        const routeName = operationDoc?.operationId;
+        router[methodName](routeName, koaPath, async (ctx, next) => {
           for (const fn of middleware) {
             await fn(ctx, next);
           }


### PR DESCRIPTION
the koa-router is able to generate URLs from named routes

this means if we use the operationId in the koa route
creation we can call `router.url` later with the operationId
and generate the URL as expected

For example, the OpenAPI operation

```
/foo/{foo_id}:
  parameters
    - name: foo_id
      in: path
  get:
    operationId: bar
```

can be used with `route.url` as such:

```
const url = ctx.router.url('bar', { foo_id: 'hello' });
// `url` is "/foo/hello"
```