### PR TITLE
README example wasn't linking routes to the app

### DIFF
--- a/packages/koa-openapi/README.md
+++ b/packages/koa-openapi/README.md
@@ -186,6 +186,8 @@ This getting started guide will use the most fundamental concepts of OpenAPI and
       },
       paths: './api-v1/paths'
     });
+    
+    app.use( router.routes() );
 
     app.listen(3000);
     ```


### PR DESCRIPTION
As the title says. The routes are created. Just not attached to the app. :-)

