### PR TITLE
openapi-request-validator: fix: nullability for allOf, anyOf, oneOf

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -598,7 +598,7 @@ function sanitizeReadonlyPropertiesFromRequired(
 function recursiveTransformOpenAPIV3Definitions(object) {
   // Transformations //
   // OpenAPIV3 nullable
-  if (object.type && object.nullable === true) {
+  if (object.nullable === true) {
     if (object.enum) {
       // Enums can not be null with type null
       object.oneOf = [
@@ -610,8 +610,14 @@ function recursiveTransformOpenAPIV3Definitions(object) {
       ];
       delete object.type;
       delete object.enum;
-    } else {
+    } else if (object.type) {
       object.type = [object.type, 'null'];
+    } else if (object.allOf) {
+      object.anyOf = [{ allOf: object.allOf }, { type: 'null' }];
+      delete object.allOf;
+    } else if (object.oneOf || object.anyOf) {
+      const arr: any[] = object.oneOf || object.anyOf;
+      arr.push({ type: 'null' });
     }
 
     delete object.nullable;

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-on-allOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-on-allOf.js
@@ -1,0 +1,29 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                nullable: true,
+                allOf: [{ type: 'string' }],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  request: {
+    body: {
+      foo: null,
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-on-anyOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-on-anyOf.js
@@ -1,0 +1,29 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                nullable: true,
+                anyOf: [{ type: 'string' }, { type: 'boolean' }],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  request: {
+    body: {
+      foo: null,
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-on-oneOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-nullable-on-oneOf.js
@@ -1,0 +1,29 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                nullable: true,
+                oneOf: [{ type: 'string' }, { type: 'boolean' }],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  request: {
+    body: {
+      foo: null,
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-value-on-nullable-on-allOf.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-value-on-nullable-on-allOf.js
@@ -1,0 +1,29 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                nullable: true,
+                allOf: [{ type: 'string' }],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  request: {
+    body: {
+      foo: 'fooValue',
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+};


### PR DESCRIPTION
```nullable: true``` validation didn't work on schemas like ```{
                nullable: true,
                allOf: [{ type: 'string' }]
              }``` because there was no type-property.

This change handles allOf, anyOf, oneOf. Please see the added tests that would fail to validate the requests on null-values.