### PR TITLE
openapi-framework: Fix externalSchemas index type

### DIFF
--- a/packages/openapi-framework/src/types.ts
+++ b/packages/openapi-framework/src/types.ts
@@ -85,7 +85,7 @@ interface OpenAPIFrameworkArgs {
   dependencies?: { [service: string]: any };
   enableObjectCoercion?: boolean;
   errorTransformer?: OpenAPIErrorTransformer;
-  externalSchemas?: { string: IJsonSchema };
+  externalSchemas?: { [index: string]: IJsonSchema };
   pathSecurity?: PathSecurityTuple[];
   operations?: { [operationId: string]: (...arg: any[]) => any };
   paths?: string | OpenAPIFrameworkPathObject[];


### PR DESCRIPTION
Hello, 

Just noticed this error when trying to set `externalSchemas` with express-openapi in typescript. 
Typescript expects only one key in `externalSchemas` named "string" and I guess this isn't the intent:

```
src/index.ts:39:9 - error TS2322: Type '{ 'http://someurl.com/test': { description: string; type: string; properties: { name: { type: string; default: string; }; }; }; }' is not assignable to type '{ string: IJsonSchema; }'.
  Object literal may only specify known properties, and ''http://someurl.com/test'' does not exist in type '{ string: IJsonSchema; }'.
```