### PR TITLE
openapi-request-validator:  Fix readonly property for plain schema objects

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -523,6 +523,9 @@ function resolveAndSanitizeRequestBodySchema(
         prop = resolveAndSanitizeRequestBodySchema(prop, v);
       }
     });
+    requestBodySchema = sanitizeReadonlyPropertiesFromRequired(
+      requestBodySchema
+    );
   } else if ('$ref' in requestBodySchema) {
     resolved = v.getSchema(requestBodySchema.$ref);
     if (resolved && resolved.schema) {

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-object.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-missing-readonly-required-property-object.js
@@ -1,0 +1,33 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              foo: {
+                type: 'string',
+                readOnly: true,
+              },
+              bar: {
+                type: 'string',
+              },
+            },
+            required: ['foo', 'bar'],
+          },
+        },
+      },
+    },
+    componentSchemas: {},
+  },
+  request: {
+    body: {
+      bar: 'asdf',
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+};


### PR DESCRIPTION
This just handles the case in which your request body schema is a plain object and not a ref
