### PR TITLE
openapi-request-validator: Make `parameters` arg optional

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -18,7 +18,7 @@ export interface OpenAPIRequestValidatorArgs {
   };
   loggingKey?: string;
   logger?: Logger;
-  parameters: OpenAPI.Parameters;
+  parameters?: OpenAPI.Parameters;
   requestBody?: OpenAPIV3.RequestBodyObject;
   schemas?: IJsonSchema[];
   componentSchemas?: IJsonSchema[];


### PR DESCRIPTION
For an openapi `OperationObject`, the `parameters` property is optional:
https://github.com/kogosoftwarellc/open-api/blob/983a1c79e54e9bcef6eea43fe22615591c919aa1/packages/openapi-types/index.ts#L97
It would be useful for the equivalent parameter of the validator to be optional so that a valid operation can be easily passed to the validator.