### PR TITLE
openapi-request-coercer: Implement coercion for deepObject style parameters

### DIFF
--- a/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-object-params-in-request-openapi3.js
@@ -5,14 +5,39 @@ module.exports = {
       {
         in: 'query',
         schema: {
+          type: 'object',
+          properties: {
+            number: { type: 'number' },
+            string: { type: 'string' },
+          },
+        },
+        style: 'deepObject',
+        name: 'deepObject',
+        required: false,
+      },
+      {
+        in: 'query',
+        schema: {
+          type: 'object',
+          additionalProperties: {
+            type: 'number',
+          },
+        },
+        style: 'deepObject',
+        name: 'additionalProperties',
+        required: false,
+      },
+      {
+        in: 'query',
+        schema: {
           type: 'array',
           items: {
             schema: {
               type: 'object',
-              // optional format property not passed meaning default coercer will kick in
             },
           },
         },
+        // style property not passed meaning the default coercer will kick in
         name: 'include',
         required: false,
       },
@@ -20,11 +45,10 @@ module.exports = {
         in: 'query',
         schema: {
           type: 'object',
-          // optional format property not passed meaning the default coercer will kick in
         },
+        // style property not passed meaning the default coercer will kick in
         name: 'query',
         required: false,
-        // optional format property not passed meaning the default coercer will kick in
       },
     ],
   },
@@ -36,6 +60,11 @@ module.exports = {
         JSON.stringify({ association: 'people', include: ['hairColor'] }),
       ],
       query: JSON.stringify({ where: { $status: 2 } }),
+      deepObject: { number: '3', string: '3' },
+      additionalProperties: {
+        width: '1',
+        length: '2',
+      },
     },
   },
 
@@ -44,10 +73,8 @@ module.exports = {
       { association: 'lines', include: ['status'] },
       { association: 'people', include: ['hairColor'] },
     ],
-    query: {
-      where: {
-        $status: 2,
-      },
-    },
+    query: { where: { $status: 2 } },
+    deepObject: { number: 3, string: '3' },
+    additionalProperties: { width: 1, length: 2 },
   },
 };


### PR DESCRIPTION
OpenAPI 3.0 defines some serializations for objects/arrays in parameters. This implements support for the `deepObject` serialization by enabling coercers to be applied recursively based on the schema. 

The object serialization must still be enabled by the `enableObjectCoercion` flag, and if the style is not set to `deepObject`, then it uses the previous `JSON.parse` solution.