### PR TITLE
Add support for customKeywords in openapi-request-validator

### DIFF
--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -33,6 +33,8 @@ and validation.
   * See [Configuring Middleware](#configuring-middleware)
 * Supports custom `format` validators.
   * See [args.customFormats](#argscustomformats)
+* Supports custom `keywords` validators (`openapi-request-validator` only).
+  * See [args.customKeywords](#argscustomkeywords)
 * Supports `collectionFormat` for `formData` `array` parameters.
 * Conforms to the [single responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle).
 * Clean interface.
@@ -68,6 +70,7 @@ https://github.com/kogosoftwarellc/open-api/tree/master/packages/express-openapi
     * [args.app](#argsapp)
     * [args.consumesMiddleware](#argsconsumesmiddleware)
     * [args.customFormats](#argscustomformats)
+    * [args.customKeywords](#argscustomkeywords)
     * [args.dependencies](#argsdependencies)
     * [args.docsPath](#argsdocspath)
     * [args.enableObjectCoercion](#argsenableobjectcoercion)
@@ -521,6 +524,36 @@ initialize({
 ```
 
 See Custom Formats in [jsonschema](https://github.com/tdegrunt/jsonschema#custom-formats).
+
+#### args.customKeywords
+
+|Type|Required|Default Value|Description|
+|----|--------|-------------|-----------|
+|Object|N|null|An object of AJV KeywordDefinitions.|
+
+Each key is the name of a custom keyword. Each value is an AJV keyword definition.
+Asynchronous keywords are not suported!
+
+```javascript
+initialize({
+  /*...*/
+  customKeywords: {
+    'x-custom-keyword': {
+      modifying: false,
+      errors: false,
+      validate: function () {
+        return true;
+      }
+    }
+  }
+  /*...*/
+});
+```
+
+See Custom Keywords in [AJV](https://ajv.js.org/custom.html).
+
+See example [with-customKeywords](https://github.com/kogosoftwarellc/open-api/tree/master/packages/express-openapi/test/sample-projects/with-customKeywords)
+on how to use custom keywords for type coercion.
 
 #### args.dependencies
 

--- a/packages/express-openapi/test/sample-projects/with-customKeywords/api-doc.js
+++ b/packages/express-openapi/test/sample-projects/with-customKeywords/api-doc.js
@@ -1,0 +1,16 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0',
+  },
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {},
+};

--- a/packages/express-openapi/test/sample-projects/with-customKeywords/api-routes/coerce.js
+++ b/packages/express-openapi/test/sample-projects/with-customKeywords/api-routes/coerce.js
@@ -1,0 +1,32 @@
+module.exports = {
+  get: function (req, res) {
+    res.status(200).json({
+      isoDateString: req.query.milliseconds.toISOString(),
+      ignoredString: req.query.ignore,
+    });
+  },
+};
+
+module.exports.get.apiDoc = {
+  description: 'Coerce milliseconds since unix-epoch to javascript Date',
+  operationId: 'coerce',
+  parameters: [
+    {
+      name: 'milliseconds',
+      in: 'query',
+      type: 'string',
+      'x-coerce': 'Date',
+    },
+    {
+      name: 'ignore',
+      in: 'query',
+      type: 'string',
+      'x-coerce': 'Ignore',
+    },
+  ],
+  responses: {
+    200: {
+      description: 'Testing custom keywords',
+    },
+  },
+};

--- a/packages/express-openapi/test/sample-projects/with-customKeywords/app.js
+++ b/packages/express-openapi/test/sample-projects/with-customKeywords/app.js
@@ -1,0 +1,50 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  paths: path.resolve(__dirname, 'api-routes'),
+  customKeywords: {
+    'x-coerce': {
+      modifying: true,
+      errors: false,
+      validate: function (
+        keywordData,
+        data,
+        parentSchema,
+        dataPath,
+        parentData,
+        parentDataProperty,
+        rootData
+      ) {
+        if (keywordData === 'Date') {
+          const date = new Date(parseInt(data, 10));
+          if (isNaN(date.getTime())) {
+            return false;
+          }
+          parentData[parentDataProperty] = date;
+        }
+        return true;
+      },
+    },
+  },
+});
+
+app.use(function (err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+const port = parseInt(process.argv[2], 10);
+if (port) {
+  app.listen(port);
+}

--- a/packages/express-openapi/test/sample-projects/with-customKeywords/spec.js
+++ b/packages/express-openapi/test/sample-projects/with-customKeywords/spec.js
@@ -1,0 +1,40 @@
+var app;
+var request = require('supertest');
+
+before(function () {
+  app = require('./app.js');
+});
+
+describe('customKeywords', function () {
+  it('should pass when the data is valid', function (done) {
+    let now = new Date();
+    request(app)
+      .get(`/v3/coerce?milliseconds=${now.getTime()}&ignore=foo`)
+      .expect(
+        200,
+        { isoDateString: now.toISOString(), ignoredString: 'foo' },
+        done
+      );
+  });
+
+  it('should fail when the data is invalid', function (done) {
+    let now = new Date();
+    request(app)
+      .get(`/v3/coerce?milliseconds=foo&ignore=foo`)
+      .expect(
+        400,
+        {
+          errors: [
+            {
+              errorCode: 'x-coerce.openapi.requestValidation',
+              location: 'query',
+              message: 'should pass "x-coerce" keyword validation',
+              path: 'milliseconds',
+            },
+          ],
+          status: 400,
+        },
+        done
+      );
+  });
+});

--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -70,6 +70,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
   public readonly loggingPrefix;
   public readonly name;
   private customFormats;
+  private customKeywords;
   private dependencies;
   private enableObjectCoercion;
   private errorTransformer;
@@ -151,6 +152,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
       extensions: this.apiDoc[`x-${this.name}-schema-extension`],
     });
     this.customFormats = args.customFormats;
+    this.customKeywords = args.customKeywords;
     this.dependencies = args.dependencies;
     this.errorTransformer = args.errorTransformer;
     this.externalSchemas = args.externalSchemas;
@@ -478,6 +480,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                     : undefined,
                   externalSchemas: this.externalSchemas,
                   customFormats: this.customFormats,
+                  customKeywords: this.customKeywords,
                   requestBody: resolveRequestBodyRefs(
                     this,
                     operationDoc.requestBody,

--- a/packages/openapi-framework/src/types.ts
+++ b/packages/openapi-framework/src/types.ts
@@ -9,6 +9,7 @@ import {
 import { IJsonSchema, OpenAPI, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import { Logger } from 'ts-log';
 import BasePath from './BasePath';
+import * as Ajv from 'ajv';
 export {
   OpenAPIFrameworkArgs,
   OpenAPIFrameworkConstructorArgs,
@@ -82,6 +83,7 @@ interface OpenAPIFrameworkConstructorArgs extends OpenAPIFrameworkArgs {
 interface OpenAPIFrameworkArgs {
   apiDoc: OpenAPIV2.Document | OpenAPIV3.Document | string;
   customFormats?: { [format: string]: (arg: any) => boolean };
+  customKeywords?: { [keywordName: string]: Ajv.KeywordDefinition };
   dependencies?: { [service: string]: any };
   enableObjectCoercion?: boolean;
   errorTransformer?: OpenAPIErrorTransformer;

--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -13,6 +13,9 @@ export interface OpenAPIRequestValidatorArgs {
   customFormats?: {
     [formatName: string]: Ajv.FormatValidator | Ajv.FormatDefinition;
   };
+  customKeywords?: {
+    [keywordName: string]: Ajv.KeywordDefinition;
+  };
   externalSchemas?: {
     [index: string]: IJsonSchema;
   };
@@ -140,6 +143,14 @@ export default class OpenAPIRequestValidator
         throw new Error(
           `${loggingKey}args.customFormats properties must be functions`
         );
+      }
+    }
+
+    if (args.customKeywords) {
+      for (const [keywordName, keywordDefinition] of Object.entries(
+        args.customKeywords
+      )) {
+        v.addKeyword(keywordName, keywordDefinition);
       }
     }
 


### PR DESCRIPTION
We use the added AJV customKeyword argument for type coercion in openapi-request-validator. This may fix #628?

This PR affects multiple packages so I made a single commit for every package. I hope that's the correct way?

Please review! :)