### PR TITLE
openapi-response-validator: Mark optional fields as optional in TypeScript types

### DIFF
--- a/packages/openapi-response-validator/index.ts
+++ b/packages/openapi-response-validator/index.ts
@@ -11,17 +11,17 @@ export interface IOpenAPIResponseValidator {
 }
 
 export interface OpenAPIResponseValidatorArgs {
-  customFormats: {
+  customFormats?: {
     [formatName: string]: Ajv.FormatValidator | Ajv.FormatDefinition;
   };
-  definitions: {
+  definitions?: {
     [definitionName: string]: IJsonSchema;
   };
   components?: OpenAPIV3.ComponentsObject;
-  externalSchemas: {
+  externalSchemas?: {
     [index: string]: IJsonSchema;
   };
-  loggingKey: string;
+  loggingKey?: string;
   responses: {
     [responseCode: string]: {
       schema: OpenAPIV2.Schema | OpenAPIV3.SchemaObject;


### PR DESCRIPTION
With given `openapi-response-validator` initialization:
```ts
new OpenAPIResponseValidator({
    responses: {…},
    components: {…},
});
```

I'm getting following error:
```
Argument of type '{ responses: any; components: any; }' is not assignable to parameter of type 'OpenAPIResponseValidatorArgs'.
Type '{ responses: any; components: any; }' is missing the following properties from type 'OpenAPIResponseValidatorArgs':
customFormats, definitions, externalSchemas, loggingKey
```

However, as these keys are marked as optional in readme, they should be marked as optional in types, I believe.

I'm not sure why tests in the repository aren't failing with this error, hence no changes in tests.