### PR TITLE
openapi-types: Add safe extension access.

### DIFF
--- a/packages/openapi-types/CHANGELOG.md
+++ b/packages/openapi-types/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 - 2021-01-05
+### Added
+- Added an index signature to `OperationObject` to allow access to extensions.
+
+### Fixed
+- Added `undefined` to the index signature for `PathsObject` to prevent unsafe null access when `strictNullChecks` is enabled.
+
 ## 1.3.5 - 2019-05-13
 ### Fixed
 - Amended missing usage of PathsObject in OpenAPIV3.Document interface.

--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -69,7 +69,7 @@ export namespace OpenAPIV3 {
   }
 
   export interface PathsObject {
-    [pattern: string]: PathItemObject;
+    [pattern: string]: PathItemObject | undefined;
   }
 
   export interface PathItemObject {
@@ -101,6 +101,10 @@ export namespace OpenAPIV3 {
     deprecated?: boolean;
     security?: SecurityRequirementObject[];
     servers?: ServerObject[];
+
+    // OpenAPI extensions can be accessed using indexing notation
+    // e.g. operationObject['x-amazon-apigateway-integration']
+    [extension: string]: unknown;
   }
 
   export interface ExternalDocumentationObject {


### PR DESCRIPTION
This change adds an index signature to the `openapi-types` package's `OperationObject` to allow access to OpenAPI extensions.

Additionally, `undefined` was added to the index signature on `PathsObject` to ensure safe access when `strictNullChecks` is enabled.