### PR TITLE
openapi-request-validator: Add ability to validate schemas that references schema object properties.

### DIFF
--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-components-property-ref.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-components-property-ref.js
@@ -1,0 +1,51 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            newFoo: {
+              $ref: '#/components/schemas/Test1/properties/foo',
+            },
+            newBaz: {
+              $ref:
+                '#/components/schemas/Test1/properties/bar/allOf/0/properties/baz',
+            },
+          },
+        },
+      },
+    },
+    schemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  baz: {
+                    type: 'number',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  request: {
+    body: {
+      newFoo: 'asdf',
+      newBaz: 123,
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+};

--- a/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-definitions-property-ref-v3.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-requestBody-with-definitions-property-ref-v3.js
@@ -1,0 +1,51 @@
+module.exports = {
+  validateArgs: {
+    parameters: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            newFoo: {
+              $ref: '#/components/schemas/Test1/properties/foo',
+            },
+            newBaz: {
+              $ref:
+                '#/components/schemas/Test1/properties/bar/allOf/0/properties/baz',
+            },
+          },
+        },
+      },
+    },
+    componentSchemas: {
+      Test1: {
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  baz: {
+                    type: 'number',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  request: {
+    body: {
+      newFoo: 'asdf',
+      newBaz: 123,
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+};


### PR DESCRIPTION
Hello!

I am opening this PR to add the ability to validate schemas that reference properties of object schema definitions.

## Given
```json
{
  "paths": {
    "/login": {
      "requestBody": {
        "content": {
          "application/json": {
            "schema": {
              "type": "object",
              "properties": {
                "login": {
                  "oneOf": [
                    {
                      "$ref": "#/components/schemas/User/properties/username"
                    },
                    {
                      "$ref": "#/components/schemas/User/properties/email"
                    }
                  ]
                },
                "password": {
                  "$ref": "#/components/schemas/schemas/User/properties/password"
                }
              }
            }
          }
        },
        "required": true
      }
    }
  },
  "components": {
    "schemas": {
      "User": {
        "type": "object",
        "properties": {
          "id": {
            "type": "string"
          },
          "username": {
            "type": "string"
          },
          "email": {
            "type": "string",
            "format": "email"
          },
          "password": {
            "type": "string",
            "minLength": 8
          },
          "data": {
            "oneOf": [
              {
                "type": "object",
                "properties": {
                  "foo": {
                    "type": "number"
                  }
                }
              },
              {
                "type": "object",
                "properties": {
                  "bar": {
                    "type": "string"
                  }
                }
              }
            ]
          },
          "list": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "baz": {
                  "type": "boolean"
                }
              }
            }
          }
        }
      }
    }
  }
}
```

## The Problem
Currently when a request is made, the validation responds that it cannot resolve the following references:
```json
[
  {
    "path": "login",
    "message": "can't resolve reference #/components/schemas/User/properties/username",
    "location": "body",
    "schema": {
      "$ref": "#/components/schemas/User/properties/username"
    }
  },
  {
    "path": "login",
    "message": "can't resolve reference #/components/schemas/User/properties/email",
    "location": "body",
    "schema": {
      "$ref": "#/components/schemas/User/properties/email"
    }
  },
  {
    "path": "login",
    "errorCode": "oneOf.openapi.requestValidation",
    "message": "should match exactly one schema in oneOf",
    "location": "body"
  },
  {
    "path": "password",
    "message": "can't resolve reference #/components/schemas/User/properties/password",
    "location": "body",
    "schema": {
      "$ref": "#/components/schemas/User/properties/password"
    }
  }
]
```

## The Solution
I added the [addSchemaProperties](https://github.com/kogosoftwarellc/open-api/pull/708/files#diff-daa4ad21e23f2dfc8102f5c63fedd13f910d41d0f6ec671cb126423f59651147R377) method that will traverse each schema's nested properties recursively and add it to the [v](https://github.com/kogosoftwarellc/open-api/blob/master/packages/openapi-request-validator/index.ts#L97). With this, properties should be reference-able no matter how deep they are in their schema definitions.

It also takes into account:
* the combiner keywords `oneOf`, `allOf`, and `anyOf`, which should be reference-able as `#/components/schemas/User/properties/data/oneOf/1/properties/bar`.
* `items` of an array type, which should be reference-able as `#/components/schemas/User/properties/list/items/properties/baz`.

Regards,
@zishone