### PR TITLE
coerce formdata openapiv3

### DIFF
--- a/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/api-doc.yml
+++ b/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/api-doc.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: express-openapi sample project
+  version: '3.0.0'
+paths:
+  /test:
+    post:
+      description: Echo back the request body to test type coercion
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                age:
+                  type: integer
+                isCool:
+                  type: boolean
+                  x-openapi-coercion-strict: true
+      responses:
+        200:
+          description: An echo of the request body.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  age:
+                    type: integer
+                  isCool:
+                    type: boolean

--- a/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/api-routes/test.js
+++ b/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/api-routes/test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  post: function (req, res, next) {
+    res.send(req.body);
+  },
+};

--- a/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/app.js
+++ b/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/app.js
@@ -1,0 +1,27 @@
+const app = require('express')();
+const bodyParser = require('body-parser');
+const fs = require('fs');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+const openapi = require('../../../');
+const path = require('path');
+const cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.urlencoded({ extended: false }));
+
+openapi.initialize({
+  apiDoc: fs.readFileSync(path.resolve(__dirname, 'api-doc.yml'), 'utf8'),
+  app: app,
+  paths: path.resolve(__dirname, 'api-routes'),
+});
+
+app.use(function (err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+const port = parseInt(process.argv[2], 10);
+if (port) {
+  app.listen(port);
+}

--- a/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/spec.js
+++ b/packages/express-openapi/test/sample-projects/with-openapiv3-formdata-params/spec.js
@@ -1,0 +1,18 @@
+const app = require('./app');
+const expect = require('chai').expect;
+const request = require('supertest');
+
+it('should coerce the types on formData fields', function (done) {
+  request(app)
+    .post('/test')
+    .send('name=Fred&isCool=true&age=38')
+    .expect(200)
+    .end(function (err, res) {
+      expect(res.body).to.eql({
+        name: 'Fred',
+        isCool: true,
+        age: 38,
+      });
+      done(err);
+    });
+});

--- a/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/api-doc.yml
+++ b/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/api-doc.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: koa-openapi sample project
+  version: '3.0.0'
+paths:
+  /test:
+    post:
+      description: Echo back the request body to test type coercion
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                age:
+                  type: integer
+                isCool:
+                  type: boolean
+                  x-openapi-coercion-strict: true
+      responses:
+        200:
+          description: An echo of the request body.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  age:
+                    type: integer
+                  isCool:
+                    type: boolean

--- a/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/api-routes/test.js
+++ b/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/api-routes/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  post: function (ctx) {
+    ctx.status = 200;
+    ctx.body = ctx.request.body;
+  },
+};

--- a/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/app.js
+++ b/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/app.js
@@ -1,0 +1,34 @@
+'use strict';
+const Koa = require('koa');
+const app = new Koa();
+const Router = require('koa-router');
+const router = new Router();
+const bodyParser = require('koa-bodyparser');
+const path = require('path');
+const openapi = require('../../../');
+const fs = require('fs');
+
+app.use(async (ctx, next) => {
+  try {
+    await next();
+  } catch (e) {
+    ctx.status = e.status;
+    if (e.errors) {
+      ctx.body = {
+        status: e.status || 500,
+        errors: e.errors,
+      };
+    }
+  }
+});
+
+app.use(bodyParser());
+
+openapi.initialize({
+  apiDoc: fs.readFileSync(path.resolve(__dirname, 'api-doc.yml'), 'utf8'),
+  router,
+  paths: path.resolve(__dirname, 'api-routes'),
+});
+
+app.use(router.routes());
+module.exports = app;

--- a/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/spec.js
+++ b/packages/koa-openapi/test/sample-projects/with-openapiv3-formdata-params/spec.js
@@ -1,0 +1,35 @@
+'use strict';
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const http = require('http');
+
+describe('with openapiv3 formData params', () => {
+  let app;
+  let request;
+  let server;
+
+  before(function () {
+    app = require('./app.js');
+    server = http.createServer(app.callback());
+    request = supertest(server);
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it('should coerce the types on formData fields', function (done) {
+    request
+      .post('/test')
+      .send('name=Fred&isCool=true&age=38')
+      .expect(200)
+      .end(function (err, res) {
+        expect(res.body).to.eql({
+          name: 'Fred',
+          isCool: true,
+          age: 38,
+        });
+        done(err);
+      });
+  });
+});

--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -458,6 +458,11 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
               )
             );
             operationContext.methodParameters = methodParameters;
+            const requestBody = resolveRequestBodyRefs(
+              this,
+              operationDoc.requestBody,
+              this.apiDoc
+            ) as OpenAPIV3.RequestBodyObject;
 
             if (methodParameters.length || operationDoc.requestBody) {
               // defaults, coercion, and parameter validation middleware
@@ -481,11 +486,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                   externalSchemas: this.externalSchemas,
                   customFormats: this.customFormats,
                   customKeywords: this.customKeywords,
-                  requestBody: resolveRequestBodyRefs(
-                    this,
-                    operationDoc.requestBody,
-                    this.apiDoc
-                  ) as OpenAPIV3.RequestBodyObject,
+                  requestBody,
                 });
                 operationContext.features.requestValidator = requestValidator;
                 this.logger.debug(
@@ -508,6 +509,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                   extensionBase: `x-${this.name}-coercion`,
                   loggingKey: `${this.name}-coercion`,
                   parameters: methodParameters,
+                  requestBody,
                   enableObjectCoercion: this.enableObjectCoercion,
                 });
 

--- a/packages/openapi-request-coercer/test/data-driven/coerce-form-data-openapi3.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-form-data-openapi3.js
@@ -1,0 +1,46 @@
+module.exports = {
+  args: {
+    parameters: [],
+    requestBody: {
+      required: true,
+      content: {
+        'application/x-www-form-urlencoded': {
+          schema: {
+            type: 'object',
+            properties: {
+              intField: {
+                type: 'integer',
+              },
+              boolField: {
+                type: 'boolean',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  request: {
+    method: 'post',
+    path: '/',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: {
+      intField: '100',
+      boolField: 'false',
+    },
+  },
+
+  headers: null,
+
+  params: null,
+
+  query: null,
+
+  body: {
+    intField: 100,
+    boolField: false,
+  },
+};


### PR DESCRIPTION
- **openapi-request-coercer: Support oapiv3 formdata**
    
    In OpenAPI v3, formData requests are specified using the
    'application/x-www-form-urlencoded' content-type inside the
    `requestBody` section of the operation. This commit adds support for
    coercing those formData parameters.
    
- **openapi-framework: Pass requestBody to coercer**
    
    In OpenAPIv3, formData is specified as a part of the `requestBody` field
    of the operation. This commit passes the `requestBody` to the coercer so
    that it can pull the formData parameters out and coerce them.

Related to #710.