### PR TITLE
openapi-types: Extract HTTP methods to enum to allow programmatic access

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -81,21 +81,30 @@ export namespace OpenAPIV3 {
     [pattern: string]: PathItemObject<T> | undefined;
   }
 
-  export interface PathItemObject<T extends {} = {}> {
+  // All HTTP methods allowed by OpenAPI 3 spec
+  // See https://swagger.io/specification/#path-item-object
+  // You can use keys or values from it in TypeScript code like this:
+  //     for (const method of Object.values(OpenAPIV3.HttpMethods)) { … }
+  export enum HttpMethods {
+    GET = 'get',
+    PUT = 'put',
+    POST = 'post',
+    DELETE = 'delete',
+    OPTIONS = 'options',
+    HEAD = 'head',
+    PATCH = 'patch',
+    TRACE = 'trace',
+  }
+
+  export type PathItemObject<T extends {} = {}> = {
     $ref?: string;
     summary?: string;
     description?: string;
-    get?: OperationObject<T>;
-    put?: OperationObject<T>;
-    post?: OperationObject<T>;
-    delete?: OperationObject<T>;
-    options?: OperationObject<T>;
-    head?: OperationObject<T>;
-    patch?: OperationObject<T>;
-    trace?: OperationObject<T>;
     servers?: ServerObject[];
     parameters?: (ReferenceObject | ParameterObject)[];
-  }
+  } & {
+    [method in HttpMethods]?: OperationObject<T>;
+  };
 
   export type OperationObject<T extends {} = {}> = {
     tags?: string[];
@@ -508,18 +517,26 @@ export namespace OpenAPIV2 {
     allowEmptyValue?: boolean;
   }
 
-  export interface PathItemObject<T extends {} = {}> {
-    $ref?: string;
-    get?: OperationObject<T>;
-    put?: OperationObject<T>;
-    post?: OperationObject<T>;
-    del?: OperationObject<T>;
-    delete?: OperationObject<T>;
-    options?: OperationObject<T>;
-    head?: OperationObject<T>;
-    patch?: OperationObject<T>;
-    parameters?: Parameters;
+  // All HTTP methods allowed by OpenAPI 2 spec
+  // See https://swagger.io/specification/v2#path-item-object
+  // You can use keys or values from it in TypeScript code like this:
+  //     for (const method of Object.values(OpenAPIV2.HttpMethods)) { … }
+  export enum HttpMethods {
+    GET = 'get',
+    PUT = 'put',
+    POST = 'post',
+    DELETE = 'delete',
+    OPTIONS = 'options',
+    HEAD = 'head',
+    PATCH = 'patch',
   }
+
+  export type PathItemObject<T extends {} = {}> = {
+    $ref?: string;
+    parameters?: Parameters;
+  } & {
+    [method in HttpMethods]?: OperationObject<T>;
+  };
 
   export interface PathsObject<T extends {} = {}> {
     [index: string]: PathItemObject<T> | any;


### PR DESCRIPTION
If I want programmatically inspect or preprocess spec, then I'm in trouble when I want to iterate over all possible HTTP methods inside every path, I have to duplicate list of HTTP from [spec's `PathItemObject`](https://swagger.io/specification/#path-item-object) verbs in my code, and after that TypeScript will throw an error because it can't figure out that all of array elements are declared in `PathItemObject` type definition:

```typescript
import { OpenAPIV3 } from "openapi-types"

const apiSpec: <OpenAPIV3.Document> = { … }

for (const methods of Object.values(schema.paths)) {
    for (const method of ["get", "post", "put", "delete", "options", "head", "patch", "trace"]) {
      const pathItem = methods[method] // ERROR!
      //               ~~~~~~~~~~~~~~~
      // Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'PathItemObject'.
      //   No index signature with a parameter of type 'string' was found on type 'PathItemObject'. ts(7053)
```

Thankfully, in TypeScript we can declare enums and [use their keys and values in runtime](https://www.typescriptlang.org/docs/handbook/enums.html#enums-at-runtime), like this:

```typescript
enum HttpMethods {
    GET = 'get',
    PUT = 'put',
    POST = 'post',
    DELETE = 'delete',
}

Object.values(HttpMethods).map(values => …)
```

So, by adding such an enum and rewriting `PathItemObject` using it as index signature, we can do following:

```typescript
import { OpenAPIV3 } from "openapi-types"

const apiSpec: <OpenAPIV3.Document> = { … }

for (const methods of Object.values(schema.paths)) {
    for (const method of Object.values(OpenAPIV3.HttpMethods)) {
      const pathItem = methods[method] // ok, method definitely is one of HttpMethods values and pathItem is a pathItemObject
```

Sure, I can define such an enum in my code (and add some additional type casting), but I think that keeping it in the package is the right thing. 

As a side effect, `PathItemObject` definitions became a little bit more self-documented (here are metadata and here are http verbs with corresponding `OperationObject`s). 

**Notes**

- I had to convert interfaces to types because of following error if I tried to add index signature to an interface:

  ```typescript
  export interface PathItemObject<T extends {} = {}> {
    $ref?: string;
    parameters?: Parameters;
    [method:HttpMethods]: OperationObject<T>;
  // ~~~~~~
  // An index signature parameter type cannot be a union type. Consider using a mapped object type instead.ts(1337)
  ```

  Types and interfaces are _almost_ the same, but TypeScript doesn't allow to add new properties to existing types. See [Advanced Types / Interfaces vs. Type Aliases](https://www.typescriptlang.org/docs/handbook/advanced-types.html#interfaces-vs-type-aliases). Not sure how crucial it is.

- As set of allowed HTTP verbs for OpenAPI 2 and 3 is different ([OpenAPI 3 allows `TRACE`](https://swagger.io/specification#path-item-object) while [OpenAPI 2 does not](https://swagger.io/specification/v2#path-item-object)), I had to create separate enums.

- For OpenAPI 2 `PathItemObject` there was `DEL` HTTP verb specified, however [it doesn't exist in the spec](https://swagger.io/specification/v2#path-item-object). [It was added along with other types](https://github.com/kogosoftwarellc/open-api/commit/55afbd82a928bd8dfc75fe75c0e204086222d0da#diff-85ecd49e6a29c7911c49cc702b39330a7d47d3ed7a65ce132cef6eb1da6dad34R164) on `openapi-types` package creation and I couldn't find any reasons why it exists. So I dropped it.