### PR TITLE
openapi-request-validator: Added check for whether readOnly prop is i…

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -642,7 +642,9 @@ function sanitizeReadonlyPropertiesFromRequired(
       .filter((i) => i !== undefined)
       .forEach((value) => {
         const index = schema.required.indexOf(value);
-        schema.required.splice(index, 1);
+        if (index !== -1) {
+          schema.required.splice(index, 1);
+        }
       });
   }
   return schema;

--- a/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-body-property-with-read-only-property.js
+++ b/packages/openapi-request-validator/test/data-driven/fail-a-missing-required-body-property-with-read-only-property.js
@@ -1,0 +1,46 @@
+module.exports = {
+  validateArgs: {
+    properties: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/TestBody',
+          },
+        },
+      },
+    },
+    componentSchemas: {
+      TestBody: {
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+        required: ['foo'],
+      },
+    },
+  },
+  request: {
+    body: {},
+    headers: {
+      'content-type': 'application/json',
+    },
+  },
+  expectedError: {
+    status: 400,
+    errors: [
+      {
+        path: 'foo',
+        errorCode: 'required.openapi.requestValidation',
+        message: "should have required property 'foo'",
+        location: 'body',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
- Fixes issue #717 where required fields are ignored if there is a non-required readOnly property in the schema