### PR TITLE
openapi-schema-validator: upgrade ajv to version 8 and use json schema draft 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9261,9 +9261,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "tslint": "6.1.2",
     "tslint-config-prettier": "1.18.0",
     "tslint-plugin-prettier": "2.3.0",
-    "typescript": "3.9.7"
+    "typescript": "^4.2.4"
   }
 }

--- a/packages/openapi-schema-validator/index.ts
+++ b/packages/openapi-schema-validator/index.ts
@@ -1,5 +1,6 @@
-import * as Ajv from 'ajv';
-const openapi2Schema = require('swagger-schema-official/schema.json');
+import ajv, { ValidateFunction, ErrorObject } from 'ajv';
+import addFormats from 'ajv-formats';
+const openapi2Schema = require('./resources/openapi-2.0.json');
 const openapi3Schema = require('./resources/openapi-3.0.json');
 const merge = require('lodash.merge');
 import { IJsonSchema, OpenAPI } from 'openapi-types';
@@ -18,14 +19,14 @@ export interface OpenAPISchemaValidatorArgs {
 }
 
 export interface OpenAPISchemaValidatorResult {
-  errors: Ajv.ErrorObject[];
+  errors: ErrorObject[];
 }
 
 export default class OpenAPISchemaValidator implements IOpenAPISchemaValidator {
-  private validator: Ajv.ValidateFunction;
+  private validator: ValidateFunction;
   constructor(args: OpenAPISchemaValidatorArgs) {
-    const v = new Ajv({ schemaId: 'auto', allErrors: true });
-    v.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
+    const v = new ajv({ allErrors: true, strict: false });
+    addFormats(v);
     const version = (args && parseInt(String(args.version), 10)) || 2;
     const schema = merge(
       {},

--- a/packages/openapi-schema-validator/package-lock.json
+++ b/packages/openapi-schema-validator/package-lock.json
@@ -5,14 +5,22 @@
 	"requires": true,
 	"dependencies": {
 		"ajv": {
-			"version": "6.12.3",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-			"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+			"integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
 				"uri-js": "^4.2.2"
+			}
+		},
+		"ajv-formats": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.0.2.tgz",
+			"integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
+			"requires": {
+				"ajv": "^8.0.0"
 			}
 		},
 		"fast-deep-equal": {
@@ -20,35 +28,33 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-		},
 		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
 		},
+		"openapi-types": {
+			"version": "8.0.0"
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
-		"swagger-schema-official": {
-			"version": "2.0.0-bab6bed",
-			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"requires": {
 				"punycode": "^2.1.0"
 			}

--- a/packages/openapi-schema-validator/package.json
+++ b/packages/openapi-schema-validator/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/kogosoftwarellc/open-api/tree/master/packages/openapi-schema-validator#readme",
   "dependencies": {
-    "ajv": "^6.5.2",
+    "ajv": "^8.1.0",
+    "ajv-formats": "^2.0.2",
     "lodash.merge": "^4.6.1",
-    "openapi-types": "^8.0.0",
-    "swagger-schema-official": "2.0.0-bab6bed"
+    "openapi-types": "^8.0.0"
   }
 }

--- a/packages/openapi-schema-validator/resources/openapi-2.0.json
+++ b/packages/openapi-schema-validator/resources/openapi-2.0.json
@@ -1,0 +1,1591 @@
+{
+    "title": "A JSON Schema for Swagger 2.0 API.",
+    "$id": "http://swagger.io/v2/schema.json#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+      "swagger",
+      "info",
+      "paths"
+    ],
+    "additionalProperties": false,
+    "patternProperties": {
+      "^x-": {
+        "$ref": "#/definitions/vendorExtension"
+      }
+    },
+    "properties": {
+      "swagger": {
+        "type": "string",
+        "enum": [
+          "2.0"
+        ],
+        "description": "The Swagger version of this document."
+      },
+      "info": {
+        "$ref": "#/definitions/info"
+      },
+      "host": {
+        "type": "string",
+        "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
+        "description": "The host (name or ip) of the API. Example: 'swagger.io'"
+      },
+      "basePath": {
+        "type": "string",
+        "pattern": "^/",
+        "description": "The base path to the API. Example: '/api'."
+      },
+      "schemes": {
+        "$ref": "#/definitions/schemesList"
+      },
+      "consumes": {
+        "description": "A list of MIME types accepted by the API.",
+        "$ref": "#/definitions/mediaTypeList"
+      },
+      "produces": {
+        "description": "A list of MIME types the API can produce.",
+        "$ref": "#/definitions/mediaTypeList"
+      },
+      "paths": {
+        "$ref": "#/definitions/paths"
+      },
+      "definitions": {
+        "$ref": "#/definitions/definitions"
+      },
+      "parameters": {
+        "$ref": "#/definitions/parameterDefinitions"
+      },
+      "responses": {
+        "$ref": "#/definitions/responseDefinitions"
+      },
+      "security": {
+        "$ref": "#/definitions/security"
+      },
+      "securityDefinitions": {
+        "$ref": "#/definitions/securityDefinitions"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/tag"
+        },
+        "uniqueItems": true
+      },
+      "externalDocs": {
+        "$ref": "#/definitions/externalDocs"
+      }
+    },
+    "definitions": {
+      "info": {
+        "type": "object",
+        "description": "General information about the API.",
+        "required": [
+          "version",
+          "title"
+        ],
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A unique and precise title of the API."
+          },
+          "version": {
+            "type": "string",
+            "description": "A semantic version number of the API."
+          },
+          "description": {
+            "type": "string",
+            "description": "A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed."
+          },
+          "termsOfService": {
+            "type": "string",
+            "description": "The terms of service for the API."
+          },
+          "contact": {
+            "$ref": "#/definitions/contact"
+          },
+          "license": {
+            "$ref": "#/definitions/license"
+          }
+        }
+      },
+      "contact": {
+        "type": "object",
+        "description": "Contact information for the owners of the API.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The identifying name of the contact person/organization."
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL pointing to the contact information.",
+            "format": "uri"
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address of the contact person/organization.",
+            "format": "email"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "license": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL pointing to the license.",
+            "format": "uri"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "paths": {
+        "type": "object",
+        "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          },
+          "^/": {
+            "$ref": "#/definitions/pathItem"
+          }
+        },
+        "additionalProperties": false
+      },
+      "definitions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/schema"
+        },
+        "description": "One or more JSON objects describing the schemas being consumed and produced by the API."
+      },
+      "parameterDefinitions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/parameter"
+        },
+        "description": "One or more JSON representations for parameters"
+      },
+      "responseDefinitions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/response"
+        },
+        "description": "One or more JSON representations for parameters"
+      },
+      "externalDocs": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "information about external documentation",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "examples": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "mimeType": {
+        "type": "string",
+        "description": "The MIME type of the HTTP message."
+      },
+      "operation": {
+        "type": "object",
+        "required": [
+          "responses"
+        ],
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "summary": {
+            "type": "string",
+            "description": "A brief summary of the operation."
+          },
+          "description": {
+            "type": "string",
+            "description": "A longer description of the operation, GitHub Flavored Markdown is allowed."
+          },
+          "externalDocs": {
+            "$ref": "#/definitions/externalDocs"
+          },
+          "operationId": {
+            "type": "string",
+            "description": "A unique identifier of the operation."
+          },
+          "produces": {
+            "description": "A list of MIME types the API can produce.",
+            "$ref": "#/definitions/mediaTypeList"
+          },
+          "consumes": {
+            "description": "A list of MIME types the API can consume.",
+            "$ref": "#/definitions/mediaTypeList"
+          },
+          "parameters": {
+            "$ref": "#/definitions/parametersList"
+          },
+          "responses": {
+            "$ref": "#/definitions/responses"
+          },
+          "schemes": {
+            "$ref": "#/definitions/schemesList"
+          },
+          "deprecated": {
+            "type": "boolean",
+            "default": false
+          },
+          "security": {
+            "$ref": "#/definitions/security"
+          }
+        }
+      },
+      "pathItem": {
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "$ref": {
+            "type": "string"
+          },
+          "get": {
+            "$ref": "#/definitions/operation"
+          },
+          "put": {
+            "$ref": "#/definitions/operation"
+          },
+          "post": {
+            "$ref": "#/definitions/operation"
+          },
+          "delete": {
+            "$ref": "#/definitions/operation"
+          },
+          "options": {
+            "$ref": "#/definitions/operation"
+          },
+          "head": {
+            "$ref": "#/definitions/operation"
+          },
+          "patch": {
+            "$ref": "#/definitions/operation"
+          },
+          "parameters": {
+            "$ref": "#/definitions/parametersList"
+          }
+        }
+      },
+      "responses": {
+        "type": "object",
+        "description": "Response objects names can either be any valid HTTP status code or 'default'.",
+        "minProperties": 1,
+        "additionalProperties": false,
+        "patternProperties": {
+          "^([0-9]{3})$|^(default)$": {
+            "$ref": "#/definitions/responseValue"
+          },
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "not": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          }
+        }
+      },
+      "responseValue": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/response"
+          },
+          {
+            "$ref": "#/definitions/jsonReference"
+          }
+        ]
+      },
+      "response": {
+        "type": "object",
+        "required": [
+          "description"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/schema"
+              },
+              {
+                "$ref": "#/definitions/fileSchema"
+              }
+            ]
+          },
+          "headers": {
+            "$ref": "#/definitions/headers"
+          },
+          "examples": {
+            "$ref": "#/definitions/examples"
+          }
+        },
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "headers": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/header"
+        }
+      },
+      "header": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "integer",
+              "boolean",
+              "array"
+            ]
+          },
+          "format": {
+            "type": "string"
+          },
+          "items": {
+            "$ref": "#/definitions/primitivesItems"
+          },
+          "collectionFormat": {
+            "$ref": "#/definitions/collectionFormat"
+          },
+          "default": {
+            "$ref": "#/definitions/default"
+          },
+          "maximum": {
+            "$ref": "#/definitions/maximum"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/definitions/exclusiveMaximum"
+          },
+          "minimum": {
+            "$ref": "#/definitions/minimum"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/definitions/exclusiveMinimum"
+          },
+          "maxLength": {
+            "$ref": "#/definitions/maxLength"
+          },
+          "minLength": {
+            "$ref": "#/definitions/minLength"
+          },
+          "pattern": {
+            "$ref": "#/definitions/pattern"
+          },
+          "maxItems": {
+            "$ref": "#/definitions/maxItems"
+          },
+          "minItems": {
+            "$ref": "#/definitions/minItems"
+          },
+          "uniqueItems": {
+            "$ref": "#/definitions/uniqueItems"
+          },
+          "enum": {
+            "$ref": "#/definitions/enum"
+          },
+          "multipleOf": {
+            "$ref": "#/definitions/multipleOf"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "vendorExtension": {
+        "description": "Any property starting with x- is valid.",
+        "additionalProperties": true,
+        "additionalItems": true
+      },
+      "bodyParameter": {
+        "type": "object",
+        "required": [
+          "name",
+          "in",
+          "schema"
+        ],
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the parameter."
+          },
+          "in": {
+            "type": "string",
+            "description": "Determines the location of the parameter.",
+            "enum": [
+              "body"
+            ]
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Determines whether or not this parameter is required or optional.",
+            "default": false
+          },
+          "schema": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "additionalProperties": false
+      },
+      "headerParameterSubSchema": {
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "required": {
+            "type": "boolean",
+            "description": "Determines whether or not this parameter is required or optional.",
+            "default": false
+          },
+          "in": {
+            "type": "string",
+            "description": "Determines the location of the parameter.",
+            "enum": [
+              "header"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the parameter."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "integer",
+              "array"
+            ]
+          },
+          "format": {
+            "type": "string"
+          },
+          "items": {
+            "$ref": "#/definitions/primitivesItems"
+          },
+          "collectionFormat": {
+            "$ref": "#/definitions/collectionFormat"
+          },
+          "default": {
+            "$ref": "#/definitions/default"
+          },
+          "maximum": {
+            "$ref": "#/definitions/maximum"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/definitions/exclusiveMaximum"
+          },
+          "minimum": {
+            "$ref": "#/definitions/minimum"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/definitions/exclusiveMinimum"
+          },
+          "maxLength": {
+            "$ref": "#/definitions/maxLength"
+          },
+          "minLength": {
+            "$ref": "#/definitions/minLength"
+          },
+          "pattern": {
+            "$ref": "#/definitions/pattern"
+          },
+          "maxItems": {
+            "$ref": "#/definitions/maxItems"
+          },
+          "minItems": {
+            "$ref": "#/definitions/minItems"
+          },
+          "uniqueItems": {
+            "$ref": "#/definitions/uniqueItems"
+          },
+          "enum": {
+            "$ref": "#/definitions/enum"
+          },
+          "multipleOf": {
+            "$ref": "#/definitions/multipleOf"
+          }
+        }
+      },
+      "queryParameterSubSchema": {
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "required": {
+            "type": "boolean",
+            "description": "Determines whether or not this parameter is required or optional.",
+            "default": false
+          },
+          "in": {
+            "type": "string",
+            "description": "Determines the location of the parameter.",
+            "enum": [
+              "query"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the parameter."
+          },
+          "allowEmptyValue": {
+            "type": "boolean",
+            "default": false,
+            "description": "allows sending a parameter by name only or with an empty value."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "integer",
+              "array"
+            ]
+          },
+          "format": {
+            "type": "string"
+          },
+          "items": {
+            "$ref": "#/definitions/primitivesItems"
+          },
+          "collectionFormat": {
+            "$ref": "#/definitions/collectionFormatWithMulti"
+          },
+          "default": {
+            "$ref": "#/definitions/default"
+          },
+          "maximum": {
+            "$ref": "#/definitions/maximum"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/definitions/exclusiveMaximum"
+          },
+          "minimum": {
+            "$ref": "#/definitions/minimum"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/definitions/exclusiveMinimum"
+          },
+          "maxLength": {
+            "$ref": "#/definitions/maxLength"
+          },
+          "minLength": {
+            "$ref": "#/definitions/minLength"
+          },
+          "pattern": {
+            "$ref": "#/definitions/pattern"
+          },
+          "maxItems": {
+            "$ref": "#/definitions/maxItems"
+          },
+          "minItems": {
+            "$ref": "#/definitions/minItems"
+          },
+          "uniqueItems": {
+            "$ref": "#/definitions/uniqueItems"
+          },
+          "enum": {
+            "$ref": "#/definitions/enum"
+          },
+          "multipleOf": {
+            "$ref": "#/definitions/multipleOf"
+          }
+        }
+      },
+      "formDataParameterSubSchema": {
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "required": {
+            "type": "boolean",
+            "description": "Determines whether or not this parameter is required or optional.",
+            "default": false
+          },
+          "in": {
+            "type": "string",
+            "description": "Determines the location of the parameter.",
+            "enum": [
+              "formData"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the parameter."
+          },
+          "allowEmptyValue": {
+            "type": "boolean",
+            "default": false,
+            "description": "allows sending a parameter by name only or with an empty value."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "integer",
+              "array",
+              "file"
+            ]
+          },
+          "format": {
+            "type": "string"
+          },
+          "items": {
+            "$ref": "#/definitions/primitivesItems"
+          },
+          "collectionFormat": {
+            "$ref": "#/definitions/collectionFormatWithMulti"
+          },
+          "default": {
+            "$ref": "#/definitions/default"
+          },
+          "maximum": {
+            "$ref": "#/definitions/maximum"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/definitions/exclusiveMaximum"
+          },
+          "minimum": {
+            "$ref": "#/definitions/minimum"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/definitions/exclusiveMinimum"
+          },
+          "maxLength": {
+            "$ref": "#/definitions/maxLength"
+          },
+          "minLength": {
+            "$ref": "#/definitions/minLength"
+          },
+          "pattern": {
+            "$ref": "#/definitions/pattern"
+          },
+          "maxItems": {
+            "$ref": "#/definitions/maxItems"
+          },
+          "minItems": {
+            "$ref": "#/definitions/minItems"
+          },
+          "uniqueItems": {
+            "$ref": "#/definitions/uniqueItems"
+          },
+          "enum": {
+            "$ref": "#/definitions/enum"
+          },
+          "multipleOf": {
+            "$ref": "#/definitions/multipleOf"
+          }
+        }
+      },
+      "pathParameterSubSchema": {
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "required": [
+          "required"
+        ],
+        "properties": {
+          "required": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Determines whether or not this parameter is required or optional."
+          },
+          "in": {
+            "type": "string",
+            "description": "Determines the location of the parameter.",
+            "enum": [
+              "path"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the parameter."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "integer",
+              "array"
+            ]
+          },
+          "format": {
+            "type": "string"
+          },
+          "items": {
+            "$ref": "#/definitions/primitivesItems"
+          },
+          "collectionFormat": {
+            "$ref": "#/definitions/collectionFormat"
+          },
+          "default": {
+            "$ref": "#/definitions/default"
+          },
+          "maximum": {
+            "$ref": "#/definitions/maximum"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/definitions/exclusiveMaximum"
+          },
+          "minimum": {
+            "$ref": "#/definitions/minimum"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/definitions/exclusiveMinimum"
+          },
+          "maxLength": {
+            "$ref": "#/definitions/maxLength"
+          },
+          "minLength": {
+            "$ref": "#/definitions/minLength"
+          },
+          "pattern": {
+            "$ref": "#/definitions/pattern"
+          },
+          "maxItems": {
+            "$ref": "#/definitions/maxItems"
+          },
+          "minItems": {
+            "$ref": "#/definitions/minItems"
+          },
+          "uniqueItems": {
+            "$ref": "#/definitions/uniqueItems"
+          },
+          "enum": {
+            "$ref": "#/definitions/enum"
+          },
+          "multipleOf": {
+            "$ref": "#/definitions/multipleOf"
+          }
+        }
+      },
+      "nonBodyParameter": {
+        "type": "object",
+        "required": [
+          "name",
+          "in",
+          "type"
+        ],
+        "oneOf": [
+          {
+            "$ref": "#/definitions/headerParameterSubSchema"
+          },
+          {
+            "$ref": "#/definitions/formDataParameterSubSchema"
+          },
+          {
+            "$ref": "#/definitions/queryParameterSubSchema"
+          },
+          {
+            "$ref": "#/definitions/pathParameterSubSchema"
+          }
+        ]
+      },
+      "parameter": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/bodyParameter"
+          },
+          {
+            "$ref": "#/definitions/nonBodyParameter"
+          }
+        ]
+      },
+      "schema": {
+        "type": "object",
+        "description": "A deterministic version of a JSON Schema object.",
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "properties": {
+          "$ref": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "title": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+          },
+          "description": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+          },
+          "default": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+          },
+          "multipleOf": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
+          },
+          "maximum": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
+          },
+          "exclusiveMaximum": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+          },
+          "minimum": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
+          },
+          "exclusiveMinimum": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+          },
+          "maxLength": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+          },
+          "minLength": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+          },
+          "pattern": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
+          },
+          "maxItems": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+          },
+          "minItems": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+          },
+          "uniqueItems": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
+          },
+          "maxProperties": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+          },
+          "minProperties": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+          },
+          "required": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+          },
+          "enum": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/schema"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "default": {}
+          },
+          "type": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+          },
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/schema"
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/definitions/schema"
+                }
+              }
+            ],
+            "default": {}
+          },
+          "allOf": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/definitions/schema"
+            }
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/schema"
+            },
+            "default": {}
+          },
+          "discriminator": {
+            "type": "string"
+          },
+          "readOnly": {
+            "type": "boolean",
+            "default": false
+          },
+          "xml": {
+            "$ref": "#/definitions/xml"
+          },
+          "externalDocs": {
+            "$ref": "#/definitions/externalDocs"
+          },
+          "example": {}
+        },
+        "additionalProperties": false
+      },
+      "fileSchema": {
+        "type": "object",
+        "description": "A deterministic version of a JSON Schema object.",
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "format": {
+            "type": "string"
+          },
+          "title": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+          },
+          "description": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+          },
+          "default": {
+            "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+          },
+          "required": {
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "file"
+            ]
+          },
+          "readOnly": {
+            "type": "boolean",
+            "default": false
+          },
+          "externalDocs": {
+            "$ref": "#/definitions/externalDocs"
+          },
+          "example": {}
+        },
+        "additionalProperties": false
+      },
+      "primitivesItems": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "integer",
+              "boolean",
+              "array"
+            ]
+          },
+          "format": {
+            "type": "string"
+          },
+          "items": {
+            "$ref": "#/definitions/primitivesItems"
+          },
+          "collectionFormat": {
+            "$ref": "#/definitions/collectionFormat"
+          },
+          "default": {
+            "$ref": "#/definitions/default"
+          },
+          "maximum": {
+            "$ref": "#/definitions/maximum"
+          },
+          "exclusiveMaximum": {
+            "$ref": "#/definitions/exclusiveMaximum"
+          },
+          "minimum": {
+            "$ref": "#/definitions/minimum"
+          },
+          "exclusiveMinimum": {
+            "$ref": "#/definitions/exclusiveMinimum"
+          },
+          "maxLength": {
+            "$ref": "#/definitions/maxLength"
+          },
+          "minLength": {
+            "$ref": "#/definitions/minLength"
+          },
+          "pattern": {
+            "$ref": "#/definitions/pattern"
+          },
+          "maxItems": {
+            "$ref": "#/definitions/maxItems"
+          },
+          "minItems": {
+            "$ref": "#/definitions/minItems"
+          },
+          "uniqueItems": {
+            "$ref": "#/definitions/uniqueItems"
+          },
+          "enum": {
+            "$ref": "#/definitions/enum"
+          },
+          "multipleOf": {
+            "$ref": "#/definitions/multipleOf"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "security": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/securityRequirement"
+        },
+        "uniqueItems": true
+      },
+      "securityRequirement": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      },
+      "xml": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "attribute": {
+            "type": "boolean",
+            "default": false
+          },
+          "wrapped": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "tag": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "externalDocs": {
+            "$ref": "#/definitions/externalDocs"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "securityDefinitions": {
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/basicAuthenticationSecurity"
+            },
+            {
+              "$ref": "#/definitions/apiKeySecurity"
+            },
+            {
+              "$ref": "#/definitions/oauth2ImplicitSecurity"
+            },
+            {
+              "$ref": "#/definitions/oauth2PasswordSecurity"
+            },
+            {
+              "$ref": "#/definitions/oauth2ApplicationSecurity"
+            },
+            {
+              "$ref": "#/definitions/oauth2AccessCodeSecurity"
+            }
+          ]
+        }
+      },
+      "basicAuthenticationSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "basic"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "apiKeySecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "name",
+          "in"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "apiKey"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "in": {
+            "type": "string",
+            "enum": [
+              "header",
+              "query"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "oauth2ImplicitSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "flow",
+          "authorizationUrl"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "oauth2"
+            ]
+          },
+          "flow": {
+            "type": "string",
+            "enum": [
+              "implicit"
+            ]
+          },
+          "scopes": {
+            "$ref": "#/definitions/oauth2Scopes"
+          },
+          "authorizationUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "oauth2PasswordSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "flow",
+          "tokenUrl"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "oauth2"
+            ]
+          },
+          "flow": {
+            "type": "string",
+            "enum": [
+              "password"
+            ]
+          },
+          "scopes": {
+            "$ref": "#/definitions/oauth2Scopes"
+          },
+          "tokenUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "oauth2ApplicationSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "flow",
+          "tokenUrl"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "oauth2"
+            ]
+          },
+          "flow": {
+            "type": "string",
+            "enum": [
+              "application"
+            ]
+          },
+          "scopes": {
+            "$ref": "#/definitions/oauth2Scopes"
+          },
+          "tokenUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "oauth2AccessCodeSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "flow",
+          "authorizationUrl",
+          "tokenUrl"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "oauth2"
+            ]
+          },
+          "flow": {
+            "type": "string",
+            "enum": [
+              "accessCode"
+            ]
+          },
+          "scopes": {
+            "$ref": "#/definitions/oauth2Scopes"
+          },
+          "authorizationUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "tokenUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      },
+      "oauth2Scopes": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "mediaTypeList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/mimeType"
+        },
+        "uniqueItems": true
+      },
+      "parametersList": {
+        "type": "array",
+        "description": "The parameters needed to send a valid API call.",
+        "additionalItems": false,
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/parameter"
+            },
+            {
+              "$ref": "#/definitions/jsonReference"
+            }
+          ]
+        },
+        "uniqueItems": true
+      },
+      "schemesList": {
+        "type": "array",
+        "description": "The transfer protocol of the API.",
+        "items": {
+          "type": "string",
+          "enum": [
+            "http",
+            "https",
+            "ws",
+            "wss"
+          ]
+        },
+        "uniqueItems": true
+      },
+      "collectionFormat": {
+        "type": "string",
+        "enum": [
+          "csv",
+          "ssv",
+          "tsv",
+          "pipes"
+        ],
+        "default": "csv"
+      },
+      "collectionFormatWithMulti": {
+        "type": "string",
+        "enum": [
+          "csv",
+          "ssv",
+          "tsv",
+          "pipes",
+          "multi"
+        ],
+        "default": "csv"
+      },
+      "title": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+      },
+      "description": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+      },
+      "default": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+      },
+      "multipleOf": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
+      },
+      "maximum": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
+      },
+      "exclusiveMaximum": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+      },
+      "minimum": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
+      },
+      "exclusiveMinimum": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+      },
+      "maxLength": {
+        "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+      },
+      "minLength": {
+        "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+      },
+      "pattern": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
+      },
+      "maxItems": {
+        "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeInteger"
+      },
+      "minItems": {
+        "$ref": "http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0"
+      },
+      "uniqueItems": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
+      },
+      "enum": {
+        "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
+      },
+      "jsonReference": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "$ref": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }

--- a/packages/openapi-schema-validator/resources/openapi-3.0.json
+++ b/packages/openapi-schema-validator/resources/openapi-3.0.json
@@ -1,7 +1,7 @@
 {
   "title": "A JSON Schema for OpenAPI 3.0.",
-  "id": "http://openapis.org/v3/schema.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "http://openapis.org/v3/schema.json#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "description": "This is the root document object of the OpenAPI document.",
   "required": [
@@ -745,52 +745,52 @@
           "type": "boolean"
         },
         "title": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
         },
         "multipleOf": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
         },
         "maximum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
         },
         "exclusiveMaximum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
         },
         "minimum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
         },
         "exclusiveMinimum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxLength"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/maxLength"
         },
         "minLength": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minLength"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/minLength"
         },
         "pattern": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
         },
         "maxItems": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxItems"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/maxItems"
         },
         "minItems": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minItems"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/minItems"
         },
         "uniqueItems": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
         },
         "maxProperties": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxProperties"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/maxProperties"
         },
         "minProperties": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minProperties"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/minProperties"
         },
         "required": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/required"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/required"
         },
         "enum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
         },
         "type": {
           "type": "string"

--- a/packages/openapi-schema-validator/test/data-driven/fail-invalid-v2-documents.js
+++ b/packages/openapi-schema-validator/test/data-driven/fail-invalid-v2-documents.js
@@ -13,9 +13,9 @@ module.exports = {
 
   errors: [
     {
-      dataPath: '',
+      instancePath: '',
       keyword: 'required',
-      message: "should have required property 'swagger'",
+      message: "must have required property 'swagger'",
       params: {
         missingProperty: 'swagger',
       },

--- a/packages/openapi-schema-validator/test/data-driven/fail-invalid-v3-documents.js
+++ b/packages/openapi-schema-validator/test/data-driven/fail-invalid-v3-documents.js
@@ -169,22 +169,22 @@ module.exports = {
 
   errors: [
     {
-      dataPath: '',
-      keyword: 'additionalProperties',
-      message: 'should NOT have additional properties',
-      params: {
-        additionalProperty: 'swagger',
-      },
-      schemaPath: '#/additionalProperties',
-    },
-    {
-      dataPath: '',
+      instancePath: '',
       keyword: 'required',
-      message: "should have required property 'openapi'",
+      message: "must have required property 'openapi'",
       params: {
         missingProperty: 'openapi',
       },
       schemaPath: '#/required',
+    },
+    {
+      instancePath: '',
+      keyword: 'additionalProperties',
+      message: 'must NOT have additional properties',
+      params: {
+        additionalProperty: 'swagger',
+      },
+      schemaPath: '#/additionalProperties',
     },
   ],
 };


### PR DESCRIPTION
part 1 for issue #727 

AJV v6 is no longer receiving feature updates and stops receiving security updates at the end of June. AJV v6 also has an outstanding security issue (in issue).

AJV v8 does not support json schema draft 4, so along with upgrading to ajv 8, we need to switch to json schema draft 7.
I could not find the repo for openapi schema v2, so I've removed the npm dependency and included the file here to upgrade the schema to draft 7.

New typescript version is needed for the newer version of AJV