### PR TITLE
openapi-type: strictly define `ResponsesObject` type

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -501,7 +501,7 @@ export namespace OpenAPIV2 {
   } & T;
 
   export interface ResponsesObject {
-    [index: string]: Response;
+    [index: string]: Response | undefined;
     default?: Response;
   }
 

--- a/packages/openapi-types/tsconfig.json
+++ b/packages/openapi-types/tsconfig.json
@@ -4,7 +4,8 @@
     "declaration": true,
     "module": "CommonJS",
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "strict": true
   },
   "files": [
     "index.ts"


### PR DESCRIPTION
fixes #742

This PR enables strict mode for typescript.
Impressively, the project only has one issue that doesn't work in strict mode, and this PR also fixes that.
You can check this quickly by running `npx lerna run prepare` which eventually runs `tsc`.

Strict mode (and this fix) is required by our project which depends directly on `openapi-types`, so your review of this and eventual release is much appreciated.

- [X] I only have 1 commit.
- [X] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [X] I have added tests.
  - not explicitly a test, but `npx lerna run prepare` will demonstrate that the strict compilation works properly
- [X] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [X] I have added a suffix to my commit message (fixes #742)
- [X] My tests pass locally.
- [X] I have run linting against my code.
