### PR TITLE
express-openapi: upgrade to ajv v8 types imported

### DIFF
--- a/packages/express-openapi/index.ts
+++ b/packages/express-openapi/index.ts
@@ -1,4 +1,4 @@
-import { ErrorObject, FormatDefinition, FormatValidator } from 'ajv';
+import { ErrorObject, FormatDefinition, Format } from 'ajv';
 import { Application, ErrorRequestHandler, RequestHandler } from 'express';
 import OpenAPIFramework, {
   BasePath,

--- a/packages/express-openapi/package-lock.json
+++ b/packages/express-openapi/package-lock.json
@@ -90,15 +90,23 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.3",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-			"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+			"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
 				"uri-js": "^4.2.2"
+			},
+			"dependencies": {
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				}
 			}
 		},
 		"ajv-formats": {
@@ -270,12 +278,6 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
-		},
 		"fs-routes": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/fs-routes/-/fs-routes-9.0.0.tgz",
@@ -332,12 +334,6 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
-		},
-		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
 		},
 		"lodash.merge": {
 			"version": "4.6.2",


### PR DESCRIPTION
fixes the imports for ajv v8 included by @types/ajv for #727 