### PR TITLE
openapi-types: allow array items to be reference objects

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -568,7 +568,7 @@ export namespace OpenAPIV2 {
     externalDocs?: ExternalDocumentationObject;
     example?: any;
     default?: any;
-    items?: ItemsObject;
+    items?: ItemsObject | ReferenceObject;
     properties?: {
       [name: string]: SchemaObject;
     };
@@ -583,7 +583,7 @@ export namespace OpenAPIV2 {
   export interface ItemsObject {
     type: string;
     format?: string;
-    items?: ItemsObject;
+    items?: ItemsObject | ReferenceObject;
     collectionFormat?: string;
     default?: any;
     maximum?: number;


### PR DESCRIPTION
Fixes #746.
