### PR TITLE
[koa-openapi]: update `initialize` options

### DIFF
--- a/packages/koa-openapi/index.ts
+++ b/packages/koa-openapi/index.ts
@@ -20,11 +20,11 @@ export interface KoaRouter {
 
 export interface KoaOpenAPIInitializeArgs extends OpenAPIFrameworkArgs {
   consumesMiddleware?: { [mimeType: string]: Middleware };
-  docsPath: string;
-  errorMiddleware: Middleware;
-  exposeApiDocs: boolean;
+  docsPath?: string;
+  errorMiddleware?: Middleware;
+  exposeApiDocs?: boolean;
   router: KoaRouter;
-  securityFilter: Middleware;
+  securityFilter?: Middleware;
 }
 
 export function initialize(args: KoaOpenAPIInitializeArgs): OpenAPIFramework {


### PR DESCRIPTION
Make `docsPath`, `errorMiddleware`, `exposeApiDocs` & `securityFilter` options optional.
In accordance to `express-openapi` & the framework itself: https://github.com/kogosoftwarellc/open-api/blob/13ad704b645055d9baec6e047a2d1a1288edb538/packages/express-openapi/index.ts#L27-L35
