### PR TITLE
openapi-framework: add middleware for operations

### DIFF
--- a/packages/express-openapi/test/sample-projects/basic-usage-with-central-apiDoc/app.js
+++ b/packages/express-openapi/test/sample-projects/basic-usage-with-central-apiDoc/app.js
@@ -14,13 +14,20 @@ openapi.initialize({
   app: app,
   paths: path.resolve(__dirname, 'api-routes'),
   operations: {
-    getUser: function get(req, res) {
-      res.status(200).json({
-        id: req.params.id,
-        name: req.query.name,
-        age: req.query.age,
-      });
-    },
+    getUser: [
+      function (req, res, next) {
+        req.valueFromMiddleware = 'bar';
+        next();
+      },
+      function get(req, res) {
+        res.status(200).json({
+          id: req.params.id,
+          name: req.query.name,
+          age: req.query.age,
+          valueFromMiddleware: req.valueFromMiddleware,
+        });
+      },
+    ],
   },
 });
 

--- a/packages/express-openapi/test/sample-projects/basic-usage-with-central-apiDoc/spec.js
+++ b/packages/express-openapi/test/sample-projects/basic-usage-with-central-apiDoc/spec.js
@@ -19,7 +19,12 @@ it('should use defaults, coercion, and operation parameter overriding', function
     .get('/v3/users/34?name=fred')
     .expect(200)
     .end(function (err, res) {
-      expect(res.body).to.eql({ id: 34, name: 'fred', age: 80 });
+      expect(res.body).to.eql({
+        id: 34,
+        name: 'fred',
+        age: 80,
+        valueFromMiddleware: 'bar',
+      });
       done(err);
     });
 });

--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -258,14 +258,10 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
               const operationId = methodDoc.operationId;
               if (operationId && operationId in this.operations) {
                 const operation = this.operations[operationId];
-
                 acc[METHOD_ALIASES[method]] = (() => {
                   const innerFunction: any = operation;
                   innerFunction.apiDoc = methodDoc;
-                  // Operations get dependencies injected in `this`
-                  return innerFunction.bind({
-                    dependencies: { ...this.dependencies },
-                  });
+                  return innerFunction;
                 })();
               } else if (operationId === undefined) {
                 this.logger.warn(

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/apiDoc.yml
@@ -1,0 +1,12 @@
+swagger: '2.0'
+info:
+  title: sample api doc
+  version: '3'
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        default:
+          description: return foo
+          schema: {}

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/operations/foo.js
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/operations/foo.js
@@ -1,0 +1,8 @@
+module.exports = [
+  (req, res, next) => {
+    return next();
+  },
+  function getFoo() {
+    return;
+  },
+];

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/paths/foo.js
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/paths/foo.js
@@ -1,0 +1,5 @@
+module.exports = {
+  post: function () {
+    return;
+  },
+};

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-middleware/spec.ts
@@ -1,0 +1,59 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      paths: path.resolve(__dirname, './paths'),
+      operations: {
+        getFoo: require('./operations/foo'),
+      },
+    });
+  });
+
+  it('should work', () => {
+    let postFeatures;
+    let getFeatures;
+    framework.initialize({
+      visitOperation(ctx) {
+        if (ctx.methodName === 'get') {
+          getFeatures = ctx.features;
+        } else if (ctx.methodName === 'post') {
+          postFeatures = ctx.features;
+        }
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.paths['/foo']).to.eql({
+          get: {
+            operationId: 'getFoo',
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {},
+              },
+            },
+          },
+          parameters: [],
+        });
+      },
+    });
+    expect(getFeatures.responseValidator).to.not.be.undefined;
+    expect(getFeatures.requestValidator).to.be.undefined;
+    expect(getFeatures.coercer).to.be.undefined;
+    expect(getFeatures.defaultSetter).to.be.undefined;
+    expect(getFeatures.securityHandler).to.be.undefined;
+    expect(postFeatures.responseValidator).to.be.undefined;
+    expect(postFeatures.requestValidator).to.be.undefined;
+    expect(postFeatures.coercer).to.be.undefined;
+    expect(postFeatures.defaultSetter).to.be.undefined;
+    expect(postFeatures.securityHandler).to.be.undefined;
+  });
+});


### PR DESCRIPTION
The goal of this PR is to bring the functionality of `args.operations` up to speed with how `args.paths` works with regards to middleware.

While args.paths (autoload like functionality) allows you to expose an array of middleware as an operation handler, the args.operations requires that the operation handler be a function. Attempting to pass an array result in a `TypeError`

```
/path/to/project/node_modules/openapi-framework/dist/index.js:165
                                return innerFunction.bind({
                                                     ^

TypeError: innerFunction.bind is not a function
```

I believe this was first documented in #618, and can make mounting middleware awkward or impossible at times.  

This PR is may me incomplete. **If** the maintainers are open to a change like this, then I'd love to take it across the finish line. However, since I'm relatively new to the codebase, I expect I may need some guidance.

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [x] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [ ] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.