### PR TITLE
[koa-openapi] fix koa security middleware order (fixes #286 for koa)

### DIFF
--- a/packages/koa-openapi/index.ts
+++ b/packages/koa-openapi/index.ts
@@ -205,7 +205,7 @@ function createAssignApiDocMiddleware(apiDoc, operationDoc) {
 
 function createSecurityMiddleware(handler) {
   return function securityMiddleware(ctx: Context) {
-    handler.handle(ctx, (err, result) => {
+    return handler.handle(ctx, (err, result) => {
       if (err) {
         if (err.challenge) {
           ctx.set('www-authenticate', err.challenge);

--- a/packages/koa-openapi/index.ts
+++ b/packages/koa-openapi/index.ts
@@ -147,7 +147,7 @@ export function initialize(args: KoaOpenAPIInitializeArgs): OpenAPIFramework {
         }
 
         if (operationCtx.features.securityHandler) {
-          middleware.push(
+          middleware.unshift(
             createSecurityMiddleware(operationCtx.features.securityHandler)
           );
         }

--- a/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-doc.js
+++ b/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-doc.js
@@ -1,0 +1,41 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'koa-openapi sample project',
+    version: '3.0.0',
+  },
+
+  definitions: {},
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {},
+
+  // set boo for api wide security.  We'll override this for the foo route.
+  security: [
+    {
+      booAuth: [],
+      boo2Auth: [],
+    },
+  ],
+
+  securityDefinitions: {
+    booAuth: {
+      type: 'basic',
+    },
+    boo2Auth: {
+      type: 'basic',
+    },
+    failAuth: {
+      type: 'basic',
+    },
+    fooAuth: {
+      type: 'basic',
+    },
+  },
+};

--- a/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-routes/boo.js
+++ b/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-routes/boo.js
@@ -1,0 +1,15 @@
+module.exports = {
+  get: function get(ctx) {
+    ctx.status = 200;
+    ctx.body = ctx.state.boo + ctx.state.boo2;
+  },
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get boo.',
+  operationId: 'getBoo',
+  parameters: [],
+  responses: {
+    204: { description: 'testing security' },
+  },
+};

--- a/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-routes/fail.js
+++ b/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-routes/fail.js
@@ -1,0 +1,28 @@
+module.exports = {
+  get: function get(ctx) {
+    ctx.status = 200;
+    ctx.body = ctx.request.foo;
+  },
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get fail.',
+  operationId: 'getFail',
+  parameters: [
+    {
+      name: 'name',
+      in: 'query',
+      type: 'string',
+      required: true,
+      description: 'just a mandatory field',
+    },
+  ],
+  security: [
+    {
+      failAuth: [],
+    },
+  ],
+  responses: {
+    204: { description: 'testing security' },
+  },
+};

--- a/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-routes/foo.js
+++ b/packages/koa-openapi/test/sample-projects/with-securityHandlers/api-routes/foo.js
@@ -1,0 +1,20 @@
+module.exports = {
+  get: function get(ctx) {
+    ctx.status = 200;
+    ctx.body = ctx.state.foo;
+  },
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  parameters: [],
+  security: [
+    {
+      fooAuth: [],
+    },
+  ],
+  responses: {
+    204: { description: 'testing security' },
+  },
+};

--- a/packages/koa-openapi/test/sample-projects/with-securityHandlers/app.js
+++ b/packages/koa-openapi/test/sample-projects/with-securityHandlers/app.js
@@ -1,0 +1,56 @@
+var Koa = require('koa');
+var app = new Koa();
+var Router = require('koa-router');
+var router = new Router();
+var bodyParser = require('koa-bodyparser');
+var path = require('path');
+var openapi = require('../../../');
+
+app.use(async (ctx, next) => {
+  try {
+    await next();
+  } catch (e) {
+    ctx.status = e.status;
+    if (e.challenge) {
+      ctx.set('www-authenticate', e.challenge);
+    }
+    if (e.errors) {
+      ctx.body = {
+        status: e.status || 500,
+        errors: e.errors,
+      };
+    }
+  }
+});
+
+app.use(bodyParser());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  router,
+  docsPath: '/foo-docs',
+  paths: path.resolve(__dirname, 'api-routes'),
+  securityHandlers: {
+    booAuth: async function (ctx) {
+      ctx.state.boo = 'boo';
+      return true;
+    },
+    boo2Auth: async function (ctx) {
+      ctx.state.boo2 = 'boo2';
+      return true;
+    },
+    failAuth: async function (_ctx) {
+      throw {
+        status: 401,
+        challenge: 'Basic realm=foo',
+      };
+    },
+    fooAuth: async function (ctx) {
+      ctx.state.foo = 'foo';
+      return true;
+    },
+  },
+});
+
+app.use(router.routes());
+module.exports = app;

--- a/packages/koa-openapi/test/sample-projects/with-securityHandlers/spec.js
+++ b/packages/koa-openapi/test/sample-projects/with-securityHandlers/spec.js
@@ -1,0 +1,37 @@
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const http = require('http');
+
+let app;
+let request;
+let server;
+
+before(function () {
+  app = require('./app.js');
+  server = http.createServer(app.callback());
+  request = supertest(server);
+});
+
+describe('with api wide security only', function () {
+  it('should be used', function (done) {
+    request.get('/v3/boo').expect(200, 'booboo2', done);
+  });
+});
+
+describe('with operation security', function () {
+  it('should override api wide security', function (done) {
+    request.get('/v3/foo').expect(200, 'foo', done);
+  });
+});
+
+describe('when authentication fails', function () {
+  it('should respond with an error', function (done) {
+    request
+      .get('/v3/fail')
+      .expect(401)
+      .end(function (err, ctx) {
+        expect(ctx.get('www-authenticate')).to.equal('Basic realm=foo');
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
Depends on #772.

As the title of #286 says, "Security checks run after data (body/params) validation".
This issue exposed the problem, was fixed for express in [PR 288](https://github.com/kogosoftwarellc/open-api/pull/288/files), but a fix was not included for koa.
This fixes it.