### PR TITLE
BugFix: #778 overwriting api doc

### DIFF
--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/apiDoc.yml
@@ -10,4 +10,11 @@ paths:
         default:
           description: return foo
           schema: {}
+  /foo-two:
+    get:
+      operationId: getFooTwo
+      responses:
+        default:
+          description: same controller mounted on another path with different operationId
+          schema: {}
   

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
@@ -18,6 +18,7 @@ describe(path.basename(__dirname), () => {
       name: 'some-framework',
       operations: {
         getFoo: require('./operations/foo'),
+        getFooTwo: require('./operations/foo')
       },
     });
   });
@@ -33,6 +34,11 @@ describe(path.basename(__dirname), () => {
       },
       visitApi(ctx) {
         const apiDoc = ctx.getApiDoc();
+
+        /**
+         * The two operations should have separate documentation,
+         * despite sharing the same controller
+         */
         expect(apiDoc.paths['/foo']).to.eql({
           parameters: [],
           get: {
@@ -40,6 +46,18 @@ describe(path.basename(__dirname), () => {
             responses: {
               default: {
                 description: 'return foo',
+                schema: {},
+              },
+            },
+          },
+        });
+        expect(apiDoc.paths['/foo-two']).to.eql({
+          parameters: [],
+          get: {
+            operationId: 'getFooTwo',
+            responses: {
+              default: {
+                description: 'same controller mounted on another path with different operationId',
                 schema: {},
               },
             },


### PR DESCRIPTION
This PR implements possible solution #1 from kogosoftwarellc#778 which is a bug that was introduced in kogosoftwarellc#769

restores behavior of binding the operation, or (new behavior) by binding each middleware in the array