### PR TITLE
BugFix: #778 dont overwrite api doc when controller is shared

### DIFF
--- a/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/api-doc.json
+++ b/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/api-doc.json
@@ -1,0 +1,31 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "sample api doc",
+    "version": "3"
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "operationId": "getFoo",
+        "responses": {
+          "default": {
+            "description": "return foo",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/foo-two": {
+      "get": {
+        "operationId": "getFooTwo",
+        "responses": {
+          "default": {
+            "description": "same controller mounted on another path with different operationId",
+            "schema": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/app.js
+++ b/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/app.js
@@ -1,0 +1,35 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+//shared controller
+function controller(req, res, next) {
+  return res.json(req.operationDoc)
+}
+
+openapi.initialize({
+  apiDoc: require('./api-doc.json'),
+  app: app,
+  promiseMode: true,
+  operations: {
+    getFoo: controller,
+    getFooTwo: controller
+  }
+});
+
+app.use(function (err, req, res, next) {
+  res.status(err.status).json(err.message);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2], 10);
+if (port) {
+  app.listen(port);
+}

--- a/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/app.js
+++ b/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/app.js
@@ -10,7 +10,7 @@ app.use(bodyParser.json());
 
 //shared controller
 function controller(req, res, next) {
-  return res.json(req.operationDoc)
+  return res.json(req.operationDoc);
 }
 
 openapi.initialize({
@@ -19,8 +19,8 @@ openapi.initialize({
   promiseMode: true,
   operations: {
     getFoo: controller,
-    getFooTwo: controller
-  }
+    getFooTwo: controller,
+  },
 });
 
 app.use(function (err, req, res, next) {

--- a/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/spec.js
+++ b/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/spec.js
@@ -1,0 +1,46 @@
+const expect = require('chai').expect;
+const request = require('supertest');
+let app
+
+before(function () {
+  app = require('./app.js')
+})
+
+it('should return the correct operationDoc for getFoo', () => {
+  const expectedDoc = {
+    operationId: 'getFoo',
+    responses: {
+      default: {
+        description: 'return foo',
+        schema: {},
+      },
+    },
+  };
+
+  request(app)
+    .get('/foo')
+    .expect(200)
+    .end(function (err, res) {
+      expect(res.body).to.eql(expectedDoc)
+    });
+
+});
+
+it('should return the correct operation doc for getFooTwo', () => {
+  const expectedDoc = {
+    operationId: 'getFooTwo',
+    responses: {
+      default: {
+        description:
+          'same controller mounted on another path with different operationId',
+        schema: {},
+      },
+    },
+  }
+  request(app)
+    .get('/foo-two')
+    .expect(200)
+    .end(function (err, res) {
+      expect(res.body).to.eql(expectedDoc)
+    });
+});

--- a/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/spec.js
+++ b/packages/express-openapi/test/sample-projects/with-multiple-operations-sharing-the-same-controller/spec.js
@@ -1,10 +1,10 @@
 const expect = require('chai').expect;
 const request = require('supertest');
-let app
+let app;
 
 before(function () {
-  app = require('./app.js')
-})
+  app = require('./app.js');
+});
 
 it('should return the correct operationDoc for getFoo', () => {
   const expectedDoc = {
@@ -21,9 +21,8 @@ it('should return the correct operationDoc for getFoo', () => {
     .get('/foo')
     .expect(200)
     .end(function (err, res) {
-      expect(res.body).to.eql(expectedDoc)
+      expect(res.body).to.eql(expectedDoc);
     });
-
 });
 
 it('should return the correct operation doc for getFooTwo', () => {
@@ -36,11 +35,11 @@ it('should return the correct operation doc for getFooTwo', () => {
         schema: {},
       },
     },
-  }
+  };
   request(app)
     .get('/foo-two')
     .expect(200)
     .end(function (err, res) {
-      expect(res.body).to.eql(expectedDoc)
+      expect(res.body).to.eql(expectedDoc);
     });
 });

--- a/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
@@ -39,7 +39,9 @@ describe(path.basename(__dirname), () => {
      */
     expect(() => {
       framework.initialize({});
-    }).to.throw(/Cannot read property 'undefined' of undefined|Cannot read properties of undefined \(reading 'undefined'\)/);
+    }).to.throw(
+      /Cannot read property 'undefined' of undefined|Cannot read properties of undefined \(reading 'undefined'\)/
+    );
     expect(warnings).to.deep.equal([
       'some-framework: path /foo, operation get is missing an operationId',
     ]);

--- a/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
@@ -33,9 +33,13 @@ describe(path.basename(__dirname), () => {
   });
 
   it('should throw an error', () => {
+    /**
+     * Node16 (really, the v8 engine) changed the error message
+     * This regex is here so that tests pass on earlier versions and Node16
+     */
     expect(() => {
       framework.initialize({});
-    }).to.throw("Cannot read property 'undefined' of undefined");
+    }).to.throw(/Cannot read property 'undefined' of undefined|Cannot read properties of undefined \(reading 'undefined'\)/);
     expect(warnings).to.deep.equal([
       'some-framework: path /foo, operation get is missing an operationId',
     ]);

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/apiDoc.yml
@@ -10,4 +10,11 @@ paths:
         default:
           description: return foo
           schema: {}
+  /foo-two:
+    get:
+      operationId: getFooTwo
+      responses:
+        default:
+          description: same controller mounted on another path with different operationId
+          schema: {}
   

--- a/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-dir-with-valid-methid-doc-after-dependency-injection/spec.ts
@@ -18,6 +18,7 @@ describe(path.basename(__dirname), () => {
       name: 'some-framework',
       operations: {
         getFoo: require('./operations/foo'),
+        getFooTwo: require('./operations/foo'),
       },
     });
   });
@@ -33,6 +34,11 @@ describe(path.basename(__dirname), () => {
       },
       visitApi(ctx) {
         const apiDoc = ctx.getApiDoc();
+
+        /**
+         * The two operations should have separate documentation,
+         * despite sharing the same controller
+         */
         expect(apiDoc.paths['/foo']).to.eql({
           parameters: [],
           get: {
@@ -40,6 +46,19 @@ describe(path.basename(__dirname), () => {
             responses: {
               default: {
                 description: 'return foo',
+                schema: {},
+              },
+            },
+          },
+        });
+        expect(apiDoc.paths['/foo-two']).to.eql({
+          parameters: [],
+          get: {
+            operationId: 'getFooTwo',
+            responses: {
+              default: {
+                description:
+                  'same controller mounted on another path with different operationId',
                 schema: {},
               },
             },


### PR DESCRIPTION
This PR implements possible solution 1️⃣   from #778 which is a bug that was introduced in #769
It restores behavior of binding the operation, or (new behavior) by binding each middleware in the array.

I think it is worth some discussion about if this is the _correct_ fix and hopefully this can help kick start the conversation.

~All tests are currently passing, but linting is not. Just need to make some small tweaks to make prettier happy.~