### PR TITLE
openapi-framework: fix typing operations (allow array)

### DIFF
--- a/packages/openapi-framework/src/types.ts
+++ b/packages/openapi-framework/src/types.ts
@@ -89,7 +89,11 @@ interface OpenAPIFrameworkArgs {
   errorTransformer?: OpenAPIErrorTransformer;
   externalSchemas?: { [index: string]: IJsonSchema };
   pathSecurity?: PathSecurityTuple[];
-  operations?: { [operationId: string]: (...arg: any[]) => any };
+  operations?: {
+    [operationId: string]:
+      | ((...arg: any[]) => any)
+      | ((...arg: any[]) => any)[];
+  };
   paths?: string | OpenAPIFrameworkPathObject[];
   pathsIgnore?: RegExp;
   routesGlob?: string;


### PR DESCRIPTION
Hello, small change to the typing of the `operations` attribute in order for it to be aligned with the changes in https://github.com/kogosoftwarellc/open-api/pull/769.

No breaking change as it simply adds the array as an additional type.

Thank you 🙂 

- [x] I only have 1 commit.
- [x] My commit is prefixed with the relevant package (e.g. express-openapi: fixing something) Note: You can use the bin/commit script to automate this.
- [x] I have added tests. (well it's only typing...)
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses.
- [x] My tests pass locally.
- [x] I have run linting against my code.