### PR TITLE
openapi-framework: Allow usage without implementation

### DIFF
--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -201,7 +201,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
         : null;
 
     let paths = [];
-    let routes = [];
+    let routes: { path: string; module: any }[] = [];
     const routesCheckMap = {};
 
     if (this.paths) {
@@ -363,7 +363,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
         // operationHandler may be an array or a function.
         const operationHandler =
           pathModule[methodAlias] ||
-          routeItem.operations[(pathDoc[methodAlias] || {}).operationId];
+          routeItem.module[(pathDoc?.[methodAlias] || {}).operationId];
         const operationDoc =
           handleYaml(getMethodDoc(operationHandler)) || pathDoc[methodName];
         // consumes is defined as property of each operation or entire document

--- a/packages/openapi-framework/src/util.ts
+++ b/packages/openapi-framework/src/util.ts
@@ -210,7 +210,7 @@ export function getSecurityDefinitionByPath(openapiPath, pathSecurity) {
 
 export function getMethodDoc(operationHandler) {
   const doc =
-    operationHandler.apiDoc ||
+    (operationHandler && operationHandler.apiDoc) ||
     (Array.isArray(operationHandler)
       ? operationHandler.slice(-1)[0].apiDoc
       : null);

--- a/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/missing-operation-id/spec.ts
@@ -15,11 +15,7 @@ describe(path.basename(__dirname), () => {
       apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
       featureType: 'middleware',
       name: 'some-framework',
-      operations: {
-        getFoo(req, res) {
-          // Operation body
-        },
-      },
+      operations: {},
       logger: {
         debug: ignore,
         error: ignore,
@@ -32,16 +28,8 @@ describe(path.basename(__dirname), () => {
     });
   });
 
-  it('should throw an error', () => {
-    /**
-     * Node16 (really, the v8 engine) changed the error message
-     * This regex is here so that tests pass on earlier versions and Node16
-     */
-    expect(() => {
-      framework.initialize({});
-    }).to.throw(
-      /Cannot read property 'undefined' of undefined|Cannot read properties of undefined \(reading 'undefined'\)/
-    );
+  it('should log a warning', () => {
+    framework.initialize({});
     expect(warnings).to.deep.equal([
       'some-framework: path /foo, operation get is missing an operationId',
     ]);

--- a/packages/openapi-framework/test/sample-projects/operations-empty/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/operations-empty/apiDoc.yml
@@ -1,0 +1,18 @@
+swagger: '2.0'
+info:
+  title: sample api doc
+  version: '3'
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        default:
+          description: return foo
+          schema: {}
+    post:
+      operationId: postFoo
+      responses:
+        default:
+          description: return foo
+          schema: {}

--- a/packages/openapi-framework/test/sample-projects/operations-empty/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/operations-empty/spec.ts
@@ -1,0 +1,65 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      operations: {},
+    });
+  });
+
+  it('should work', () => {
+    let postFeatures;
+    let getFeatures;
+    framework.initialize({
+      visitOperation(ctx) {
+        if (ctx.methodName === 'get') {
+          getFeatures = ctx.features;
+        } else if (ctx.methodName === 'post') {
+          postFeatures = ctx.features;
+        }
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.paths['/foo']).to.eql({
+          get: {
+            operationId: 'getFoo',
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {},
+              },
+            },
+          },
+          post: {
+            operationId: 'postFoo',
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {},
+              },
+            },
+          },
+          parameters: [],
+        });
+      },
+    });
+    expect(getFeatures.responseValidator).to.not.be.undefined;
+    expect(getFeatures.requestValidator).to.be.undefined;
+    expect(getFeatures.coercer).to.be.undefined;
+    expect(getFeatures.defaultSetter).to.be.undefined;
+    expect(getFeatures.securityHandler).to.be.undefined;
+    expect(postFeatures.responseValidator).not.to.be.undefined;
+    expect(postFeatures.requestValidator).to.be.undefined;
+    expect(postFeatures.coercer).to.be.undefined;
+    expect(postFeatures.defaultSetter).to.be.undefined;
+    expect(postFeatures.securityHandler).to.be.undefined;
+  });
+});


### PR DESCRIPTION
This PR tried to resolve
#722 : It would be
nice to be able to use openapi-framework without an implementation, e.g.
to implement generic request validation.
Looking a the code it seem to have worked in the past, as
routeItem.operations rather looks like a typo.
