### PR TITLE
openapi-framework: Allow injecting custom classes for features

### DIFF
--- a/packages/openapi-framework/src/types.ts
+++ b/packages/openapi-framework/src/types.ts
@@ -1,12 +1,25 @@
-import { IOpenAPIDefaultSetter } from 'openapi-default-setter';
-import { IOpenAPIRequestCoercer } from 'openapi-request-coercer';
-import { IOpenAPIRequestValidator } from 'openapi-request-validator';
-import { IOpenAPIResponseValidator } from 'openapi-response-validator';
+import {
+  IOpenAPIDefaultSetter,
+  OpenAPIDefaultSetterArgs,
+} from 'openapi-default-setter';
+import {
+  IOpenAPIRequestCoercer,
+  OpenAPIRequestCoercerArgs,
+} from 'openapi-request-coercer';
+import {
+  IOpenAPIRequestValidator,
+  OpenAPIRequestValidatorArgs,
+} from 'openapi-request-validator';
+import {
+  IOpenAPIResponseValidator,
+  OpenAPIResponseValidatorArgs,
+} from 'openapi-response-validator';
 import {
   IOpenAPISecurityHandler,
+  OpenAPISecurityHandlerArgs,
   SecurityHandlers,
 } from 'openapi-security-handler';
-import { IJsonSchema, OpenAPI, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
+import { IJsonSchema, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import { Logger } from 'ts-log';
 import BasePath from './BasePath';
 import * as Ajv from 'ajv';
@@ -87,6 +100,21 @@ interface OpenAPIFrameworkArgs {
   dependencies?: { [service: string]: any };
   enableObjectCoercion?: boolean;
   errorTransformer?: OpenAPIErrorTransformer;
+  features?: {
+    coercer?: new (args: OpenAPIRequestCoercerArgs) => IOpenAPIRequestCoercer;
+    defaultSetter?: new (
+      args: OpenAPIDefaultSetterArgs
+    ) => IOpenAPIDefaultSetter;
+    requestValidator?: new (
+      args: OpenAPIRequestValidatorArgs
+    ) => IOpenAPIRequestValidator;
+    responseValidator?: new (
+      args: OpenAPIResponseValidatorArgs
+    ) => IOpenAPIResponseValidator;
+    securityHandler?: new (
+      args: OpenAPISecurityHandlerArgs
+    ) => IOpenAPISecurityHandler;
+  };
   externalSchemas?: { [index: string]: IJsonSchema };
   pathSecurity?: PathSecurityTuple[];
   operations?: {

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/apiDoc.yml
@@ -1,0 +1,8 @@
+swagger: '2.0'
+info:
+  title: sample api doc
+  version: '3'
+paths: {}
+securityDefinitions:
+  basic:
+    type: basic

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomCoercer.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomCoercer.ts
@@ -1,0 +1,16 @@
+import {
+  IOpenAPIRequestCoercer,
+  OpenAPIRequestCoercerArgs,
+} from 'openapi-request-coercer';
+
+export default class CustomCoercer implements IOpenAPIRequestCoercer {
+  private args;
+
+  constructor(args: OpenAPIRequestCoercerArgs) {
+    this.args = args;
+  }
+
+  coerce(request: any) {
+    return;
+  }
+}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomDefaultSetter.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomDefaultSetter.ts
@@ -1,0 +1,17 @@
+import {
+  IOpenAPIDefaultSetter,
+  OpenAPIDefaultSetterArgs,
+} from 'openapi-default-setter';
+import { OpenAPI } from 'openapi-types';
+
+export default class CustomDefaultSetter implements IOpenAPIDefaultSetter {
+  private args;
+
+  constructor(args: OpenAPIDefaultSetterArgs) {
+    this.args = args;
+  }
+
+  handle(request: OpenAPI.Request) {
+    return;
+  }
+}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomRequestValidator.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomRequestValidator.ts
@@ -1,0 +1,17 @@
+import {
+  IOpenAPIRequestValidator,
+  OpenAPIRequestValidatorArgs,
+} from 'openapi-request-validator';
+
+export default class CustomRequestValidator
+  implements IOpenAPIRequestValidator {
+  private args;
+
+  constructor(args: OpenAPIRequestValidatorArgs) {
+    this.args = args;
+  }
+
+  validateRequest(request: any) {
+    return;
+  }
+}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomResponseValidator.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomResponseValidator.ts
@@ -1,0 +1,20 @@
+import {
+  IOpenAPIResponseValidator,
+  OpenAPIResponseValidatorArgs,
+} from 'openapi-response-validator';
+
+export default class CustomResponseValidator
+  implements IOpenAPIResponseValidator {
+  private args;
+
+  constructor(args: OpenAPIResponseValidatorArgs) {
+    this.args = args;
+  }
+
+  validateResponse(statusCode: any, response: any) {
+    return {
+      errors: [],
+      message: 'Hello, world!',
+    };
+  }
+}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomSecurityHandler.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/features/CustomSecurityHandler.ts
@@ -1,0 +1,18 @@
+import {
+  IOpenAPISecurityHandler,
+  OpenAPISecurityHandlerArgs,
+} from 'openapi-security-handler';
+
+export default class CustomSecurityHandler implements IOpenAPISecurityHandler {
+  private args;
+
+  constructor(args: OpenAPISecurityHandlerArgs) {
+    this.args = args;
+  }
+
+  handle(request: any) {
+    return new Promise<void>((resolve) => {
+      resolve();
+    });
+  }
+}

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/paths/foo.js
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/paths/foo.js
@@ -1,0 +1,24 @@
+module.exports = {
+  GET,
+};
+
+function GET() {
+  return;
+}
+
+GET.apiDoc = {
+  parameters: [
+    {
+      name: 'name',
+      in: 'query',
+      type: 'string',
+      default: 'elvis',
+    },
+  ],
+  responses: {
+    default: {
+      description: 'return foo',
+      schema: {},
+    },
+  },
+};

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-custom-features/spec.ts
@@ -1,0 +1,85 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenapiFramework from '../../../';
+import CustomDefaultSetter from './features/CustomDefaultSetter';
+import CustomCoercer from './features/CustomCoercer';
+import CustomRequestValidator from './features/CustomRequestValidator';
+import CustomResponseValidator from './features/CustomResponseValidator';
+import CustomSecurityHandler from './features/CustomSecurityHandler';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      features: {
+        coercer: CustomCoercer,
+        defaultSetter: CustomDefaultSetter,
+        requestValidator: CustomRequestValidator,
+        responseValidator: CustomResponseValidator,
+        securityHandler: CustomSecurityHandler,
+      },
+      name: 'some-framework',
+      paths: path.resolve(__dirname, './paths'),
+      pathSecurity: [
+        [/.+/, [{ basic: [] }]],
+        [/^awes/, [{ basic: [] }]],
+      ],
+      securityHandlers: {
+        basic() {
+          return true;
+        },
+      },
+    });
+  });
+
+  it('should instantiate custom features', () => {
+    framework.initialize({
+      visitOperation(ctx) {
+        expect(ctx.features.coercer).to.be.instanceof(CustomCoercer);
+        expect(ctx.features.defaultSetter).to.be.instanceof(
+          CustomDefaultSetter
+        );
+        expect(ctx.features.requestValidator).to.be.instanceof(
+          CustomRequestValidator
+        );
+        expect(ctx.features.responseValidator).to.be.instanceof(
+          CustomResponseValidator
+        );
+        expect(ctx.features.securityHandler).to.be.instanceof(
+          CustomSecurityHandler
+        );
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.paths['/foo']).to.eql({
+          parameters: [],
+          get: {
+            parameters: [
+              {
+                name: 'name',
+                in: 'query',
+                type: 'string',
+                default: 'elvis',
+              },
+            ],
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {},
+              },
+            },
+            security: [
+              {
+                basic: [],
+              },
+            ],
+          },
+        });
+      },
+    });
+  });
+});

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-default-features/apiDoc.yml
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-default-features/apiDoc.yml
@@ -1,0 +1,8 @@
+swagger: '2.0'
+info:
+  title: sample api doc
+  version: '3'
+paths: {}
+securityDefinitions:
+  basic:
+    type: basic

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-default-features/paths/foo.js
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-default-features/paths/foo.js
@@ -1,0 +1,24 @@
+module.exports = {
+  GET,
+};
+
+function GET() {
+  return;
+}
+
+GET.apiDoc = {
+  parameters: [
+    {
+      name: 'name',
+      in: 'query',
+      type: 'string',
+      default: 'elvis',
+    },
+  ],
+  responses: {
+    default: {
+      description: 'return foo',
+      schema: {},
+    },
+  },
+};

--- a/packages/openapi-framework/test/sample-projects/paths-dir-with-default-features/spec.ts
+++ b/packages/openapi-framework/test/sample-projects/paths-dir-with-default-features/spec.ts
@@ -1,0 +1,78 @@
+/* tslint:disable:no-unused-expression */
+import { expect } from 'chai';
+import OpenAPIDefaultSetter from 'openapi-default-setter';
+import OpenAPIRequestCoercer from 'openapi-request-coercer';
+import OpenAPIRequestValidator from 'openapi-request-validator';
+import OpenAPIResponseValidator from 'openapi-response-validator';
+import OpenAPISecurityHandler from 'openapi-security-handler';
+import OpenapiFramework from '../../../';
+const path = require('path');
+
+describe(path.basename(__dirname), () => {
+  let framework: OpenapiFramework;
+
+  beforeEach(() => {
+    framework = new OpenapiFramework({
+      apiDoc: path.resolve(__dirname, 'apiDoc.yml'),
+      featureType: 'middleware',
+      name: 'some-framework',
+      paths: path.resolve(__dirname, './paths'),
+      pathSecurity: [
+        [/.+/, [{ basic: [] }]],
+        [/^awes/, [{ basic: [] }]],
+      ],
+      securityHandlers: {
+        basic() {
+          return true;
+        },
+      },
+    });
+  });
+
+  it('should instantiate default features', () => {
+    framework.initialize({
+      visitOperation(ctx) {
+        expect(ctx.features.coercer).to.be.instanceof(OpenAPIRequestCoercer);
+        expect(ctx.features.defaultSetter).to.be.instanceof(
+          OpenAPIDefaultSetter
+        );
+        expect(ctx.features.requestValidator).to.be.instanceof(
+          OpenAPIRequestValidator
+        );
+        expect(ctx.features.responseValidator).to.be.instanceof(
+          OpenAPIResponseValidator
+        );
+        expect(ctx.features.securityHandler).to.be.instanceof(
+          OpenAPISecurityHandler
+        );
+      },
+      visitApi(ctx) {
+        const apiDoc = ctx.getApiDoc();
+        expect(apiDoc.paths['/foo']).to.eql({
+          parameters: [],
+          get: {
+            parameters: [
+              {
+                name: 'name',
+                in: 'query',
+                type: 'string',
+                default: 'elvis',
+              },
+            ],
+            responses: {
+              default: {
+                description: 'return foo',
+                schema: {},
+              },
+            },
+            security: [
+              {
+                basic: [],
+              },
+            ],
+          },
+        });
+      },
+    });
+  });
+});


### PR DESCRIPTION
The current implementation does not allow defining custom classes to be used for:
* defaults setting
* coercing
* request/response validation
* security handlers

This is absolutely fine for the general use case. 

However, in very large projects this incurs a fairly large penalty on startup. For example, to perform an integration test on a single endpoint all of the classes must be instantiated for all paths/operations.

Allowing consumers to inject their own instances of these classes will support behavior like, within test environments, providing thin wrappers around the existing classes for this functionality which are lazy-initialized on any property being accessed. Lazy-initializing these classes sees fairly large improvements in integration test times for large API documents.

This may be useful for other reports of slow startup for large API documents, eg. [Issue #372](https://github.com/kogosoftwarellc/open-api/issues/372).

This could be seen as a resolution to pull requests [#737](https://github.com/kogosoftwarellc/open-api/pull/737) and [#738](https://github.com/kogosoftwarellc/open-api/pull/737) as well. Instead of having to pass AJV configuration to `OpenAPIFrameworkArgs`, consumers are able to write their own classes for request/response validation that instantiate AJV as they see fit.