### PR TITLE
openapi-request-coercer: fix header coercing

### DIFF
--- a/packages/openapi-request-coercer/index.ts
+++ b/packages/openapi-request-coercer/index.ts
@@ -140,8 +140,8 @@ function buildCoercer(args) {
 
   return (obj) => {
     for (const paramName in obj) {
-      if (coercers.hasOwnProperty(paramName)) {
-        obj[paramName] = coercers[paramName](obj[paramName]);
+      if (coercers.hasOwnProperty(l(paramName))) {
+        obj[paramName] = coercers[l(paramName)](obj[paramName]);
       }
     }
   };

--- a/packages/openapi-request-coercer/test/data-driven/coerce-headers-case-insensitive.js
+++ b/packages/openapi-request-coercer/test/data-driven/coerce-headers-case-insensitive.js
@@ -1,0 +1,22 @@
+module.exports = {
+  args: {
+    parameters: [
+      {
+        name: 'If-None-Match',
+        in: 'header',
+        description: '...',
+        schema: { type: 'array', items: { type: 'string' } },
+      },
+    ],
+  },
+
+  request: {
+    headers: {
+      'If-None-Match': '"123","321"',
+    },
+  },
+
+  headers: {
+    'If-None-Match': ['"123"', '"321"'],
+  },
+};


### PR DESCRIPTION
Header field names are case insensitive which was addressed to some extent in the code by lowercasing the properties of the `coercers` object ([here](https://github.com/kogosoftwarellc/open-api/blob/5c68224a2e85bc1a55c7a6aa29c30e5d0f873032/packages/openapi-request-coercer/index.ts#L137) via the [`l` helper function](https://github.com/kogosoftwarellc/open-api/blob/5c68224a2e85bc1a55c7a6aa29c30e5d0f873032/packages/openapi-request-coercer/index.ts#L118)). However, the function performing the coercion compared the original (non-lowercase) fields to the lowercase coercers properties ([here](https://github.com/kogosoftwarellc/open-api/blob/5c68224a2e85bc1a55c7a6aa29c30e5d0f873032/packages/openapi-request-coercer/index.ts#L143)), which doesn't work unless the header was lowercase to begin with.

This is fixed here by using the same lowercasing on the parameter name when checking for a matching coercer.
