### PR TITLE
openapi-types: Fixed OpenAPIV3_1.PathItemObject to accept OpenAPIV3_1…

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -36,7 +36,7 @@ export namespace OpenAPI {
 export namespace OpenAPIV3_1 {
   type Modify<T, R> = Omit<T, keyof R> & R;
 
-  type PathsWebhooksComponents<T> = {
+  type PathsWebhooksComponents<T extends {} = {}> = {
     paths: PathsObject<T>;
     webhooks: Record<string, PathItemObject | ReferenceObject>;
     components: ComponentsObject;
@@ -98,13 +98,13 @@ export namespace OpenAPIV3_1 {
 
   export type HttpMethods = OpenAPIV3.HttpMethods;
 
-  export type PathItemObject<T extends {} = {}> = Modify<
+  export type PathItemObject<T extends {} = {}> = Omit<Modify<
     OpenAPIV3.PathItemObject<T>,
     {
       servers?: ServerObject[];
       parameters?: (ReferenceObject | ParameterObject)[];
     }
-  > &
+  >, OpenAPIV3.HttpMethods> &
     {
       [method in HttpMethods]?: OperationObject<T>;
     };


### PR DESCRIPTION
….OperationObject

## Problem
In my project, I was trying to construct a OpenAPIV3_1 object as follows
```typescript
type OperationObjects = {
  [method in OpenAPIV3_1.HttpMethods]?: OpenAPIV3_1.OperationObject;
};
const summary = "blah";
const description = "blah";
const operationObjects = getOperationObjects(routeConfig, routeData); // Returns OperationObjects
const parameterObjects = getParamsFromPath(path); // Return OpenAPIV3_1.ParameterObject
return {
  ...operationObjects,
  parameters: parameterObjects,
  summary, // string
  description, // string
};
```

When spreading the object I get the following error: [https://pastebin.com/XwXWuavS](https://pastebin.com/XwXWuavS)

## Solution

I wouldn't consider myself a savvy typescript guy, but I assume the issue is due to the way the `method` -> `OperationObject` gets tacked on as a intersection on both V3 and V3_1. This will probably result in typescript interpreting 
```typescript
{
  [method in HttpMethods]?: OpenAPIV3.OperationObject<T>
} & 
{
  [method in HttpMethods]?: OpenAPIV3_1.OperationObject<T>
}
```
Which I assume would just boil down to
```typescript
{
  [method in HttpMethods]?: OpenAPIV3.OperationObject<T>
}
```

To solve this, I `Omit` the original mapping of `method` to `OpenAPIV3.OperationObject` and add it back as `method` to `OpenAPIV3_1.OperationObject` as an intersection at the end. I am not sure if this is the most elegant solution, but it does work.


Sidenote: I also noticed a typescript error on `PathsWebhooksComponents` which I think I fixed too
