### PR TITLE
openapi-request-validator: make mimetype header case insensitive

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -297,7 +297,7 @@ export default class OpenAPIRequestValidator
     }
 
     if (this.requestBody) {
-      const contentType = request.headers['content-type'];
+      const contentType = getHeaderValue(request.headers, 'content-type');
       const mediaTypeMatch = getSchemaForMediaType(
         contentType,
         this.requestBody,
@@ -732,4 +732,14 @@ function transformOpenAPIV3Definitions(schema) {
   const res = JSON.parse(JSON.stringify(schema));
   recursiveTransformOpenAPIV3Definitions(res);
   return res;
+}
+
+function getHeaderValue(
+  requestHeaders: { [key: string]: any },
+  header: string
+) {
+  const matchingHeaders = Object.keys(requestHeaders).filter(
+    (key) => key.toLowerCase() === header.toLowerCase()
+  );
+  return requestHeaders[matchingHeaders[0]];
 }

--- a/packages/openapi-request-validator/test/data-driven/accept-case-insensitive-content-type-header.js
+++ b/packages/openapi-request-validator/test/data-driven/accept-case-insensitive-content-type-header.js
@@ -1,0 +1,38 @@
+module.exports = {
+  validateArgs: {
+    properties: [],
+    requestBody: {
+      description: 'a test body',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/TestBody',
+          },
+        },
+      },
+      required: true,
+    },
+    componentSchemas: {
+      TestBody: {
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            type: 'string',
+            readOnly: true,
+          },
+        },
+        required: ['foo'],
+      },
+    },
+  },
+  request: {
+    body: {
+      foo: 'foo',
+    },
+    headers: {
+      'ConTent-TyPe': 'application/json',
+    },
+  },
+};


### PR DESCRIPTION
HTML headers are lowercase most of the time, but some applications (eg:AWS) may use a different case. In such cases headers like `content-type` can be sent as `Content-Type`. 

The request validator is written to throw an error when the request body is required AND  `content-type` header is not present. Currently this error is thrown if `content-type` header is not in lowercase. 

This fixes this issue and **makes the content-type header case-insensitive**