### PR TITLE
openapi-types: Add optional description field to oauth security scheme

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -550,6 +550,7 @@ export namespace OpenAPIV3 {
 
   export interface OAuth2SecurityScheme {
     type: 'oauth2';
+    description?: string;
     flows: {
       implicit?: {
         authorizationUrl: string;


### PR DESCRIPTION
The `OAuth2SecurityScheme` typescript interface is missing an optional `description` field, that other security schemes have present. According to the [specification](https://swagger.io/specification/) it can be present in any of the security schemes.