### PR TITLE
add absolute file prefix for dynamic imports

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ jobs:
           node-version: lts/*
       - run: |
           npm ci
+          npm run bootstrap
           cd packages/express-openapi
           npm run test
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,16 +2,16 @@ name: PR Build
 on: pull_request
 jobs:
   code-quality:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-      - run: |
-          npm ci
-          npm run bootstrap
-          cd packages/express-openapi
-          npm run test
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run bootstrap
+      - run: npm run cover
+      - run: npm run combine-coverage
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,16 +2,15 @@ name: PR Build
 on: pull_request
 jobs:
   code-quality:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run bootstrap
-      - run: npm run cover
-      - run: npm run combine-coverage
+      - run: |
+          npm ci
+          cd packages/express-openapi
+          npm run test
 
 

--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -235,7 +235,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                   //   as `default` property
                   // - file is a ECMAScript module, and `export default` appears
                   //   at top-level
-                  const imported = await import(fsRoutesItem.path);
+                  const imported = await import(`file://${fsRoutesItem.path}`);
                   return {
                     path: fsRoutesItem.route,
                     module: imported.default ?? imported,


### PR DESCRIPTION
Re https://github.com/kogosoftwarellc/open-api/issues/812

# Main change

Always add the `file://` prefix when loading ES moduls or CommonJS scripts.

Tested with:

- [x] Windows 11 (natively, no WSL)
- [x] Linux
- [x] MacOS , see https://github.com/kogosoftwarellc/open-api/runs/6957151421?check_suite_focus=true

# How to test

```sh
npm run bootstrap
cd packages/express-openapi
npm run test
```
