### PR TITLE
extend expressJS Request Handler Parameters through express-openapi

### DIFF
--- a/packages/express-openapi/index.ts
+++ b/packages/express-openapi/index.ts
@@ -1,3 +1,4 @@
+import * as core from 'express-serve-static-core';
 import { ErrorObject, FormatDefinition, Format } from 'ajv';
 import { Application, ErrorRequestHandler, RequestHandler } from 'express';
 import OpenAPIFramework, {
@@ -13,16 +14,34 @@ const CASE_SENSITIVE_PARAM_PROPERTY = 'x-express-openapi-case-sensitive';
 const normalizeQueryParamsMiddleware = require('express-normalize-query-params-middleware');
 const loggingPrefix = 'express-openapi';
 
-export interface OperationFunction extends RequestHandler {
+export interface OperationFunction<
+  P extends Record<string, string> = core.ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = core.Query,
+  Locals extends Record<string, any> = Record<string, any>
+> extends RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {
   apiDoc?: OpenAPI.Operation;
 }
 
-export interface OperationHandlerArray {
+export interface OperationHandlerArray<
+  P extends Record<string, string> = core.ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = core.Query,
+  Locals extends Record<string, any> = Record<string, any>
+> {
   apiDoc?: OpenAPI.Operation;
-  [index: number]: RequestHandler;
+  [index: number]: RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>;
 }
 
-export type Operation = OperationFunction | OperationHandlerArray;
+export type Operation<
+  P extends Record<string, string> = core.ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = core.Query,
+  Locals extends Record<string, any> = Record<string, any>
+> = OperationFunction<P, ResBody, ReqBody, ReqQuery, Locals> | OperationHandlerArray<P, ResBody, ReqBody, ReqQuery, Locals>;
 
 export interface ExpressOpenAPIArgs extends OpenAPIFrameworkArgs {
   app: Application;


### PR DESCRIPTION
The added generic types for RequestHandler come from expressJS and allow the user to give types to various parts of the request and response object in a way that allows typescript to infer types. Currently if the user wants typescript to infer one of these parts has a certain type they have to explicitly case the object as such. This will remove the need to cast at all. This change is necessary because with the current code the user cannot explicitly type req or res because the compiler will complain about assigning a function where they have been more defined to the Operation type since Operation is missing those specific type definitions.

For example

```
// normally generated from the openAPI definition
interface myExampleDictionary extends core.ParamsDictionary {
  key: string
}
const GET: Operation =  async (req: express.Request<myExampleDictionary>, res: express.Response, next: express.NextFunction) => {
```

Instead we currently have to do something like

```
// normally generated from the openAPI definition
interface myExampleDictionary extends core.ParamsDictionary {
  key: string
}
const GET: Operation =  async (req, res, next) => {
  const params = req.params as myExampleDictionary;
```

*Note: This checklist isn't meant to show up on the actual Pull Request (PR). It is added here to make you aware of items our maintainers will look for when reviewing your PR.  If your PR is missing any of these items it will be rejected!  Please delete this message and the following checklist and replace it with your own message as you see fit.*

- [ ] I only have 1 commit.
- [ ] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [ ] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [ ] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [ ] My tests pass locally.
- [ ] I have run linting against my code.
