### PR TITLE
openapi-jsonschema-parameters: add description to properties

### DIFF
--- a/packages/openapi-jsonschema-parameters/index.ts
+++ b/packages/openapi-jsonschema-parameters/index.ts
@@ -176,6 +176,7 @@ function getSchema(parameters, type) {
           paramSchema.examples = getExamples(param.examples);
         }
         schema.properties[param.name] = paramSchema;
+        schema.properties[param.name].description = param.description;
       } else {
         paramSchema = copyValidationKeywords(param);
         if ('examples' in paramSchema) {


### PR DESCRIPTION
convertParametersToJSONSchema returns properties without the description. 
 schema.properties[param.name].description = param.description;

*Note: This checklist isn't meant to show up on the actual Pull Request (PR). It is added here to make you aware of items our maintainers will look for when reviewing your PR.  If your PR is missing any of these items it will be rejected!  Please delete this message and the following checklist and replace it with your own message as you see fit.*

- [ ] I only have 1 commit.
- [ ] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [ ] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [ ] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [ ] My tests pass locally.
- [ ] I have run linting against my code.
