### PR TITLE
openapi-types: Add support for "const" keyword to base schema type.

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -178,6 +178,7 @@ export namespace OpenAPIV3_1 {
       discriminator?: DiscriminatorObject;
       externalDocs?: ExternalDocumentationObject;
       xml?: XMLObject;
+      const?: any;
     }
   >;
 


### PR DESCRIPTION
The "const" keyword was added in OAS 3.1, largely as syntactic sugar for a single value enum. It's been a part of the JSON schema spec since draft-06 and seems to be more common out in the wild now.
