### PR TITLE
openapi-types: fix: add description property to OpenAPIV2 HeaderObject

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -712,7 +712,9 @@ export namespace OpenAPIV2 {
     [index: string]: HeaderObject;
   }
 
-  export interface HeaderObject extends ItemsObject {}
+  export interface HeaderObject extends ItemsObject {
+    description?: string;
+  }
 
   export interface ExampleObject {
     [index: string]: any;


### PR DESCRIPTION
Currently the V2 definition of the Header Object is missing the "description" property as outlined here: https://swagger.io/specification/v2/#header-object

This PR just adds that to the HeaderObject definition, since it is not present in the ItemsObject
