### PR TITLE
express-openapi : Change non-breaking hyphen char to unicode to simple dash

### DIFF
--- a/packages/express-openapi/README.md
+++ b/packages/express-openapi/README.md
@@ -631,7 +631,7 @@ module.exports = function(geoservice) {
 
 |Type|Required|Default Value|Description|
 |----|--------|-----------|----|
-|String|N|/api&#8209;docs|Sets the path that Swagger UI will use to request `args.apiDoc` with populated paths.  You can use this to support multiple versions of your app.|
+|String|N|/api-docs|Sets the path that Swagger UI will use to request `args.apiDoc` with populated paths.  You can use this to support multiple versions of your app.|
 
 #### args.enableObjectCoercion
 


### PR DESCRIPTION
Somehow a high Unicode character snuck in where normal ASCII was preferred.