### PR TITLE
express-openapi: fixed windows path names

### DIFF
--- a/packages/express-openapi/index.ts
+++ b/packages/express-openapi/index.ts
@@ -252,7 +252,8 @@ function optionallyAddQueryNormalizationMiddleware(
 }
 
 function toExpressParams(part) {
-  return part.replace(/\{([^}]+)}/g, ':$1');
+  // Replace '{param}' with ':param' and replace any '\\' with '/'
+  return part.replace(/\{([^}]+)}/g, ':$1').replace(/\\/g, '/');
 }
 
 function toPromiseCompatibleMiddleware(fn) {


### PR DESCRIPTION
Windows path names are not being converted correctly. This modified function will take an OpenAPI path, replace all '{param}' style parameters with ':param' style (as used by Express), and also replace all backslashes (\) with forward slashes (/), making it compatible with all operating systems.

References the issue #868