### PR TITLE
 openapi-framework: fix backslahses problems when on windows

### DIFF
--- a/packages/openapi-framework/index.ts
+++ b/packages/openapi-framework/index.ts
@@ -237,7 +237,7 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
                   //   at top-level
                   const imported = await import(`file://${fsRoutesItem.path}`);
                   return {
-                    path: fsRoutesItem.route,
+                    path: fsRoutesItem.route.replace(/\\/g, '/'),
                     module: imported.default ?? imported,
                   };
                 })


### PR DESCRIPTION
 This commit solves the problem with windows file system when
 generating the swagger file with openapi-framework. With this commit
 the swagger is now generating the docs with ('/') instead of the ('\').

*Note: This checklist isn't meant to show up on the actual Pull Request (PR). It is added here to make you aware of items our maintainers will look for when reviewing your PR.  If your PR is missing any of these items it will be rejected!  Please delete this message and the following checklist and replace it with your own message as you see fit.*

- [ ] I only have 1 commit.
- [ ] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [ ] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [ ] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [ ] My tests pass locally.
- [ ] I have run linting against my code.
