### PR TITLE
fs-routes: Fixes backslash issue on Windows

### DIFF
--- a/packages/fs-routes/index.ts
+++ b/packages/fs-routes/index.ts
@@ -55,7 +55,7 @@ export default function fsRoutes(
       .sort(compare)
       .map((file) => ({
         path: path.resolve(dir, file),
-        route: '/' + file.replace(options.indexFileRegExp, ''),
+        route: '/' + file.replace(options.indexFileRegExp, '').replace(/\\/g, '/'),
       }));
   }
 


### PR DESCRIPTION
Fixes #868 and #871
