### PR TITLE
openapi-types: better autocomplete with ParamsObject in v3

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -365,11 +365,32 @@ export namespace OpenAPIV3 {
     url: string;
   }
 
-  export interface ParameterObject extends ParameterBaseObject {
-    name: string;
-    in: string;
-  }
+  export type ParameterObject = PathLocationObject | QueryLocationObject | CookieLocationObject | HeaderLocationObject; 
 
+  export interface CookieLocationObject extends ParameterBaseObject {
+    name: string;
+    in: "cookie";
+    style?: "form";
+  }
+    
+  interface HeaderLocationObject extends ParameterBaseObject {
+    name: string;
+    in: "header";
+    style?: "simple";
+  }
+    
+  interface PathLocationObject extends ParameterBaseObject {
+    name: string;
+    in: "path";
+    required: boolean;
+    style?: "matrix" | "label" | "simple";
+  }
+    
+  interface QueryLocationObject extends ParameterBaseObject {
+    name: string;
+    in: "query";
+    style?: "form" | "spaceDelimited" | "pipeDelimited" | "deepObject";
+  }
   export interface HeaderObject extends ParameterBaseObject {}
 
   export interface ParameterBaseObject {


### PR DESCRIPTION
Hello,

I find this improvement, it can be use for v3_1,
I am inspired about https://www.sheshbabu.com/posts/rust-for-javascript-developers-pattern-matching-and-enums/

What do you think ?

*Note: This checklist isn't meant to show up on the actual Pull Request (PR). It is added here to make you aware of items our maintainers will look for when reviewing your PR.  If your PR is missing any of these items it will be rejected!  Please delete this message and the following checklist and replace it with your own message as you see fit.*

- [X] I only have 1 commit.
- [X] My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [-] I have added tests.
- [X] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [-] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [x] My tests pass locally.
- [x] I have run linting against my code.
