### PR TITLE
openapi-types: A number is also allowed for a server variable value

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -311,8 +311,8 @@ export namespace OpenAPIV3 {
   }
 
   export interface ServerVariableObject {
-    enum?: string[];
-    default: string;
+    enum?: string[] | number[];
+    default: string | number;
     description?: string;
   }
 


### PR DESCRIPTION
Currently, you only accept a string as a value default value type, but a number is also allowed (eg. for a port number) in OpenAPI.

Numbers are also an accepted type here! Example use-case:

```ts
        servers: [
          {
            url: 'http://localhost:{port}/{basePath}',
            description: 'Development server',
            variables: {
              port: {
                default: 3001
              },
              basePath: {
                default: 'api/v1'
              }
            }
          }
````


- [x] I only have 1 commit.
- [x]  My commit is prefixed with the relevant package (e.g. `express-openapi: fixing something`) *Note: You can use the bin/commit script to automate this.*
- [ ] I have added tests.
- [x] I'm using the latest code from the master branch and there are no conflicts on my branch.
- [x] I have added a suffix to my commit message that will close any existing issue my PR addresses (e.g. `openapi-jsonschema-parameters: Adding examples to the validation keywords (fixes #455)`).
- [ ] My tests pass locally.
- [ ] I have run linting against my code.
