### PR TITLE
openapi-types: accept boolean JSON Schemas

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -143,7 +143,8 @@ export namespace OpenAPIV3_1 {
   export type SchemaObject =
     | ArraySchemaObject
     | NonArraySchemaObject
-    | MixedSchemaObject;
+    | MixedSchemaObject
+    | boolean;
 
   export interface ArraySchemaObject extends BaseSchemaObject {
     type: ArraySchemaObjectType;


### PR DESCRIPTION
According to https://json-schema.org/draft/2020-12/json-schema-core#section-4.3.2 a `SchemaObject` can be `true` (always pass validation) and `false` (always fail validation).