### PR TITLE
openapi-types: add mutualTLS SecuritySchemeObject

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -534,7 +534,8 @@ export namespace OpenAPIV3 {
     | HttpSecurityScheme
     | ApiKeySecurityScheme
     | OAuth2SecurityScheme
-    | OpenIdSecurityScheme;
+    | OpenIdSecurityScheme
+    | MutualTLSSecurityScheme;
 
   export interface HttpSecurityScheme {
     type: 'http';
@@ -582,6 +583,11 @@ export namespace OpenAPIV3 {
     type: 'openIdConnect';
     description?: string;
     openIdConnectUrl: string;
+  }
+
+  export interface MutualTLSSecurityScheme {
+    type: 'mutualTLS';
+    description?: string;
   }
 
   export interface TagObject {


### PR DESCRIPTION
The 3.1.0 spec allows this: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object

The 3.1.1 spec includes an example with the fields added in this PR: https://github.com/OAI/OpenAPI-Specification/pull/2625/files

There is some discussion here: https://github.com/OAI/OpenAPI-Specification/issues/2475