### PR TITLE
[openapi-types] V3.1 parameter object references V3

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -123,7 +123,9 @@ export namespace OpenAPIV3_1 {
 
   export type ExternalDocumentationObject = OpenAPIV3.ExternalDocumentationObject;
 
-  export type ParameterObject = OpenAPIV3.ParameterObject;
+  export interface ParameterObject extends Omit<OpenAPIV3.ParameterObject, "schema"> {
+    schema: ReferenceObject | SchemaObject
+  }
 
   export type HeaderObject = OpenAPIV3.HeaderObject;
 


### PR DESCRIPTION
ParameterObject for openapi 3.1 incorrectly refers to ParameterObject of openapi 3. This leads to incompetabilities with ArraySchema since it was changed in openapi 3.1.
