### PR TITLE
openapi-types: add extensions x- prefixed index signature to openapi document type

### DIFF
--- a/packages/openapi-types/index.ts
+++ b/packages/openapi-types/index.ts
@@ -283,6 +283,7 @@ export namespace OpenAPIV3 {
       | ((request: any, response: any, next: any) => void)
     )[];
     'x-express-openapi-validation-strict'?: boolean;
+    [key: `x-${string}`]: unknown;
   }
 
   export interface InfoObject {
@@ -613,6 +614,7 @@ export namespace OpenAPIV2 {
       | ((request: any, response: any, next: any) => void)
     )[];
     'x-express-openapi-validation-strict'?: boolean;
+    [key: `x-${string}`]: unknown;
   }
 
   export interface TagObject {


### PR DESCRIPTION
The spec allows extensions if with a field name matching `^x-` except for `x-oai-` and `x-oas-` which are reserved.