### PR TITLE
'openapi-request-validator' componentSchemas should be an object

### DIFF
--- a/packages/openapi-request-validator/index.ts
+++ b/packages/openapi-request-validator/index.ts
@@ -32,7 +32,7 @@ export interface OpenAPIRequestValidatorArgs {
   parameters?: OpenAPI.Parameters;
   requestBody?: OpenAPIV3.RequestBodyObject;
   schemas?: IJsonSchema[];
-  componentSchemas?: IJsonSchema[];
+  componentSchemas?: Record<string, IJsonSchema>;
   errorTransformer?(
     openAPIResponseValidatorValidationError: OpenAPIRequestValidatorError,
     ajvError: ErrorObject


### PR DESCRIPTION
# the problem
currently, the interface of the OpenAPIRequestValidator has componentSchemas as an array of IJsonSchema.

```
export interface OpenAPIRequestValidatorArgs {
  customFormats?: {
    [formatName: string]: Format | FormatDefinition<string | number>;
  };
  customKeywords?: {
    [keywordName: string]: KeywordDefinition;
  };
  externalSchemas?: {
    [index: string]: IJsonSchema;
  };
  loggingKey?: string;
  logger?: Logger;
  parameters?: OpenAPI.Parameters;
  requestBody?: OpenAPIV3.RequestBodyObject;
  schemas?: IJsonSchema[];
  componentSchemas?: IJsonSchema[];
  errorTransformer?(
    openAPIResponseValidatorValidationError: OpenAPIRequestValidatorError,
    ajvError: ErrorObject
  ): any;
  ajvOptions?: Options;
  enableHeadersLowercase?: boolean;
  additionalQueryProperties?: boolean;
}
```

but this is incorrect, in the code we rely on the fact that componentsSchema is an object: 

```
 Object.keys(args.componentSchemas).forEach((id) => {
```

with the current implementation, we will have typecheck errors whenever we try to use openapi-request-validator in TS with componentSchemas. 

# the solution
just a one line change to update that interface.
tests still pass.

