### PR TITLE
Bump js-yaml to address vulnerabilities in openapi-framework

### DIFF
--- a/packages/openapi-framework/package-lock.json
+++ b/packages/openapi-framework/package-lock.json
@@ -1,38 +1,39 @@
 {
   "name": "openapi-framework",
   "version": "12.1.3",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-framework",
-      "version": "12.1.0",
+      "version": "12.1.3",
       "license": "MIT",
       "dependencies": {
         "difunc": "0.0.4",
-        "fs-routes": "^12.0.0",
+        "fs-routes": "^12.1.3",
         "glob": "*",
         "is-dir": "^1.0.0",
-        "js-yaml": "^3.10.0",
-        "openapi-default-setter": "^12.1.0",
-        "openapi-request-coercer": "^12.1.0",
-        "openapi-request-validator": "^12.1.0",
-        "openapi-response-validator": "^12.1.0",
-        "openapi-schema-validator": "^12.1.0",
-        "openapi-security-handler": "^12.1.0",
-        "openapi-types": "^12.1.0",
+        "js-yaml": "^4.2.0",
+        "openapi-default-setter": "^12.1.3",
+        "openapi-request-coercer": "^12.1.3",
+        "openapi-request-validator": "^12.1.3",
+        "openapi-response-validator": "^12.1.3",
+        "openapi-schema-validator": "^12.1.3",
+        "openapi-security-handler": "^12.1.3",
+        "openapi-types": "^12.1.3",
         "ts-log": "^2.1.4"
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -56,12 +57,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -69,9 +68,10 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -115,10 +115,27 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fs-routes": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/fs-routes/-/fs-routes-12.0.0.tgz",
-      "integrity": "sha512-ik1ezT+N8roNkp966PG/TMDd3aocLw+VmYTJnwOiAWIq3CI90FBOM79qmZPanz5gl671O7fu1wiWeqF5IxQslQ==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/fs-routes/-/fs-routes-12.1.3.tgz",
+      "integrity": "sha512-Vwxi5StpKj/pgH7yRpNpVFdaZr16z71KNTiYuZEYVET+MfZ31Zkf7oxUmNgyZxptG8BolRtdMP90agIhdyiozg==",
+      "license": "MIT",
       "peerDependencies": {
         "glob": ">=7.1.6"
       }
@@ -167,12 +184,22 @@
       "integrity": "sha1-QdN/SV/MrMBaR3jWboMCTCkro/8="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -189,9 +216,10 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -208,75 +236,83 @@
       }
     },
     "node_modules/openapi-default-setter": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-default-setter/-/openapi-default-setter-12.1.0.tgz",
-      "integrity": "sha512-nk08UIlCr/kNpH5r7QVmjmMeapFLwJZCqesCxEciu+wuRKrq9YU/gx/D5hhRObtfpo/7ee49MJU4vwPCO65C1A==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-default-setter/-/openapi-default-setter-12.1.3.tgz",
+      "integrity": "sha512-wHKwvEuOWwke5WcQn8pyCTXT5WQ+rm9FpJmDeEVECEBWjEyB/MVLYfXi+UQeSHTTu2Tg4VDHHmzbjOqN6hYeLQ==",
+      "license": "MIT",
       "dependencies": {
-        "openapi-types": "^12.1.0"
+        "openapi-types": "^12.1.3"
       }
     },
     "node_modules/openapi-jsonschema-parameters": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-12.1.0.tgz",
-      "integrity": "sha512-JmJfBHAomeWefA9HAu5Ee9VDtLRG6C2jVwOjHXvBL8BcRw65ibYTmWMvA7MIYbPT1WHe1waUzw4An7a+Nr/RWg==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-12.1.3.tgz",
+      "integrity": "sha512-aHypKxWHwu2lVqfCIOCZeJA/2NTDiP63aPwuoIC+5ksLK5/IQZ3oKTz7GiaIegz5zFvpMDxDvLR2DMQQSkOAug==",
+      "license": "MIT",
       "dependencies": {
-        "openapi-types": "^12.1.0"
+        "openapi-types": "^12.1.3"
       }
     },
     "node_modules/openapi-request-coercer": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-request-coercer/-/openapi-request-coercer-12.1.0.tgz",
-      "integrity": "sha512-fcZSwRsE/L5coxLhCUCa7LMFBJl8lVbihkR8yXbgLr6jAKHXsKGDB9UWVyZCkJecdROSNwUHmBsnN9kScN27Aw==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-request-coercer/-/openapi-request-coercer-12.1.3.tgz",
+      "integrity": "sha512-CT2ZDhBmAZpHhAzHhEN+/J5oMK3Ds99ayLLdXh2Aw1DCcn72EM8VuIGVwG5fSjvkMsgtn7FgltFosHqeM6PRFQ==",
+      "license": "MIT",
       "dependencies": {
-        "openapi-types": "^12.1.0",
+        "openapi-types": "^12.1.3",
         "ts-log": "^2.1.4"
       }
     },
     "node_modules/openapi-request-validator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-12.1.0.tgz",
-      "integrity": "sha512-WbcX/mrRGq0GBOqf/Rv4X0vY2WUO1ZmOjrWsnRByEIIJ/6LDWVUqlgEnpVEzpDN8Z2/XoK+YPcFnqIalFmn3sA==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-12.1.3.tgz",
+      "integrity": "sha512-HW1sG00A9Hp2oS5g8CBvtaKvRAc4h5E4ksmuC5EJgmQ+eAUacL7g+WaYCrC7IfoQaZrjxDfeivNZUye/4D8pwA==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.3.0",
         "ajv-formats": "^2.1.0",
         "content-type": "^1.0.4",
-        "openapi-jsonschema-parameters": "^12.1.0",
-        "openapi-types": "^12.1.0",
+        "openapi-jsonschema-parameters": "^12.1.3",
+        "openapi-types": "^12.1.3",
         "ts-log": "^2.1.4"
       }
     },
     "node_modules/openapi-response-validator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-12.1.0.tgz",
-      "integrity": "sha512-GavGFToPoCt6iF5IZXfyXggmu4urNYmC0FN4CLJF5y8mbwWviI73Te5fybiUE2TmXvvaGSs9EKumSX7Ibxv6Sw==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-12.1.3.tgz",
+      "integrity": "sha512-beZNb6r1SXAg1835S30h9XwjE596BYzXQFAEZlYAoO2imfxAu5S7TvNFws5k/MMKMCOFTzBXSjapqEvAzlblrQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.4.0",
-        "openapi-types": "^12.1.0"
+        "openapi-types": "^12.1.3"
       }
     },
     "node_modules/openapi-schema-validator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-12.1.0.tgz",
-      "integrity": "sha512-gr9mZCHu5QmADePYNhizaSAsB0HdY/DespPue10NQID1jB+56Jf+dfnJcnMOVKsG4ZAedVY5oyLFGI1Gk0wm7w==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-12.1.3.tgz",
+      "integrity": "sha512-xTHOmxU/VQGUgo7Cm0jhwbklOKobXby+/237EG967+3TQEYJztMgX9Q5UE2taZKwyKPUq0j11dngpGjUuxz1hQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.1.0",
         "ajv-formats": "^2.0.2",
         "lodash.merge": "^4.6.1",
-        "openapi-types": "^12.1.0"
+        "openapi-types": "^12.1.3"
       }
     },
     "node_modules/openapi-security-handler": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-security-handler/-/openapi-security-handler-12.1.0.tgz",
-      "integrity": "sha512-WpEhoFFOQPheyIMaNtakfG2WJo74WPbLL5UzV7WhxvylGao1SykoVu1zRW49hHjKG/6LvM4pH4rBCqCzgbKsWw==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-security-handler/-/openapi-security-handler-12.1.3.tgz",
+      "integrity": "sha512-25UTAflxqqpjCLrN6rRhINeM1L+MCDixMltiAqtBa9Zz/i7UkWwYwdzqgZY3Cx3vRZElFD09brYxo5VleeP3HQ==",
+      "license": "MIT",
       "dependencies": {
-        "openapi-types": "^12.1.0"
+        "openapi-types": "^12.1.3"
       }
     },
     "node_modules/openapi-types": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
-      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA=="
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -284,14 +320,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
-      "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/require-from-string": {
@@ -302,283 +330,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
     "node_modules/ts-log": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.1.4.tgz",
       "integrity": "sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ=="
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    }
-  },
-  "dependencies": {
-    "ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {
-        "ajv": "^8.0.0"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "difunc": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/difunc/-/difunc-0.0.4.tgz",
-      "integrity": "sha512-zBiL4ALDmviHdoLC0g0G6wVme5bwAow9WfhcZLLopXCAWgg3AEf7RYTs2xugszIGulRHzEVDF/SHl9oyQU07Pw==",
-      "requires": {
-        "esprima": "^4.0.0"
-      }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fs-routes": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/fs-routes/-/fs-routes-12.0.0.tgz",
-      "integrity": "sha512-ik1ezT+N8roNkp966PG/TMDd3aocLw+VmYTJnwOiAWIq3CI90FBOM79qmZPanz5gl671O7fu1wiWeqF5IxQslQ==",
-      "requires": {}
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "is-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-dir/-/is-dir-1.0.0.tgz",
-      "integrity": "sha1-QdN/SV/MrMBaR3jWboMCTCkro/8="
-    },
-    "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "openapi-default-setter": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-default-setter/-/openapi-default-setter-12.1.0.tgz",
-      "integrity": "sha512-nk08UIlCr/kNpH5r7QVmjmMeapFLwJZCqesCxEciu+wuRKrq9YU/gx/D5hhRObtfpo/7ee49MJU4vwPCO65C1A==",
-      "requires": {
-        "openapi-types": "^12.1.0"
-      }
-    },
-    "openapi-jsonschema-parameters": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-12.1.0.tgz",
-      "integrity": "sha512-JmJfBHAomeWefA9HAu5Ee9VDtLRG6C2jVwOjHXvBL8BcRw65ibYTmWMvA7MIYbPT1WHe1waUzw4An7a+Nr/RWg==",
-      "requires": {
-        "openapi-types": "^12.1.0"
-      }
-    },
-    "openapi-request-coercer": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-request-coercer/-/openapi-request-coercer-12.1.0.tgz",
-      "integrity": "sha512-fcZSwRsE/L5coxLhCUCa7LMFBJl8lVbihkR8yXbgLr6jAKHXsKGDB9UWVyZCkJecdROSNwUHmBsnN9kScN27Aw==",
-      "requires": {
-        "openapi-types": "^12.1.0",
-        "ts-log": "^2.1.4"
-      }
-    },
-    "openapi-request-validator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-12.1.0.tgz",
-      "integrity": "sha512-WbcX/mrRGq0GBOqf/Rv4X0vY2WUO1ZmOjrWsnRByEIIJ/6LDWVUqlgEnpVEzpDN8Z2/XoK+YPcFnqIalFmn3sA==",
-      "requires": {
-        "ajv": "^8.3.0",
-        "ajv-formats": "^2.1.0",
-        "content-type": "^1.0.4",
-        "openapi-jsonschema-parameters": "^12.1.0",
-        "openapi-types": "^12.1.0",
-        "ts-log": "^2.1.4"
-      }
-    },
-    "openapi-response-validator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-12.1.0.tgz",
-      "integrity": "sha512-GavGFToPoCt6iF5IZXfyXggmu4urNYmC0FN4CLJF5y8mbwWviI73Te5fybiUE2TmXvvaGSs9EKumSX7Ibxv6Sw==",
-      "requires": {
-        "ajv": "^8.4.0",
-        "openapi-types": "^12.1.0"
-      }
-    },
-    "openapi-schema-validator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-12.1.0.tgz",
-      "integrity": "sha512-gr9mZCHu5QmADePYNhizaSAsB0HdY/DespPue10NQID1jB+56Jf+dfnJcnMOVKsG4ZAedVY5oyLFGI1Gk0wm7w==",
-      "requires": {
-        "ajv": "^8.1.0",
-        "ajv-formats": "^2.0.2",
-        "lodash.merge": "^4.6.1",
-        "openapi-types": "^12.1.0"
-      }
-    },
-    "openapi-security-handler": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-security-handler/-/openapi-security-handler-12.1.0.tgz",
-      "integrity": "sha512-WpEhoFFOQPheyIMaNtakfG2WJo74WPbLL5UzV7WhxvylGao1SykoVu1zRW49hHjKG/6LvM4pH4rBCqCzgbKsWw==",
-      "requires": {
-        "openapi-types": "^12.1.0"
-      }
-    },
-    "openapi-types": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
-      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA=="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "punycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
-      "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw=="
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "ts-log": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.1.4.tgz",
-      "integrity": "sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ=="
-    },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="

--- a/packages/openapi-framework/package.json
+++ b/packages/openapi-framework/package.json
@@ -31,7 +31,7 @@
     "fs-routes": "^12.1.3",
     "glob": "*",
     "is-dir": "^1.0.0",
-    "js-yaml": "^3.10.0",
+    "js-yaml": "^4.2.0",
     "openapi-default-setter": "^12.1.3",
     "openapi-request-coercer": "^12.1.3",
     "openapi-request-validator": "^12.1.3",

--- a/packages/openapi-framework/src/util.ts
+++ b/packages/openapi-framework/src/util.ts
@@ -239,7 +239,7 @@ export function handleFilePath(filePath) {
 
 export function handleYaml(apiDoc) {
   return typeof apiDoc === 'string'
-    ? jsYaml.safeLoad(apiDoc, { json: true })
+    ? jsYaml.load(apiDoc, { json: true })
     : apiDoc;
 }
 


### PR DESCRIPTION
## Issue: 
package js-yaml vulnerability in versions lower than 4.2.0
https://github.com/advisories/GHSA-h67p-54hq-rp68

## Description
I need to use a version of openapi-framework that uses js-yaml 4.2.0 or higher, in order to override this package and address vulnerabilities. The problem is that openapi-framework uses the method `jsYaml.safeLoad` which is deprecated in v4.

This Pr bumps js-yaml to version 4.2.0 and changes the deprecated `jsYaml.safeLoad` to the safer `jsYaml.Load` method

## Relevant screenshots

### before
<img width="536" height="256" alt="Screenshot 2026-06-24 at 8 10 05" src="https://github.com/user-attachments/assets/f733a77a-7d8e-42aa-a08d-869c4f19033d" />

### after
<img width="465" height="188" alt="Screenshot 2026-06-24 at 8 12 08" src="https://github.com/user-attachments/assets/ba62be64-3fb2-463e-8ca1-be49d03480c5" />


